### PR TITLE
feat (RAG Task): Support for different context per evaluation.

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -136,6 +136,8 @@ export interface Document {
   formattedText?: string;
   url?: string;
   title?: string;
+  score?: number;
+  query?: {};
   annotations?: DocumentAnnotation[];
 }
 
@@ -187,6 +189,7 @@ export interface TaskEvaluation {
   readonly annotations: {
     [key: string]: { [key: string]: Annotation };
   };
+  readonly contexts?: Document[];
   [key: string]: any;
 }
 

--- a/src/views/task/TaskCopier.tsx
+++ b/src/views/task/TaskCopier.tsx
@@ -262,7 +262,7 @@ export default function TaskCopierModal({
         </div>
         <span className={classes.heading}>Preview</span>
         <CodeSnippet
-          multi
+          type="multi"
           hideCopyButton={true}
           wrapText={true}
           className={classes.previewBox}


### PR DESCRIPTION
- For task type `rag`, different contexts can be associated with evaluations with a `contexts` field. 
- This allows researcher, developers, stake holders to run a full RAG pipeline with different retriever and generator combination on the same input (conversation). 