### PR TITLE
feat (expression): Experimental support for expression based filtering in model behavior.

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -22,7 +22,6 @@ const cspMap = {
   'base-uri': ["'none'"],
   'font-src': ["'self'", 'data:', "'unsafe-inline'"],
   'form-action': ["'self'"],
-  'frame-ancestors': ["'none'"],
   'frame-src': ["'self'"],
   'img-src': ["'self'", 'data:', 'blob:', 'www.ibm.com/'],
   'media-src': ["'self'", 'blob:', 'www.ibm.com/'],

--- a/src/components/expression-builder/ExpressionBuilder.module.scss
+++ b/src/components/expression-builder/ExpressionBuilder.module.scss
@@ -19,59 +19,22 @@
 @use '@carbon/react/scss/spacing' as *;
 @use '@carbon/colors' as *;
 
-.filtersBtnTooltip {
-  align-self: center;
-  margin-bottom: $spacing-03;
-}
-
-.filtersBtn {
-  display: flex;
-  column-gap: $spacing-04;
-  padding: $spacing-03;
-  color: inherit !important;
-}
-
-.filtersBtnElements {
-  display: flex;
-  column-gap: $spacing-04;
-  align-items: center;
-}
-
-.filtersBtnCaptionElements {
-  display: flex;
-  column-gap: $spacing-02;
-  align-items: center;
-}
-
-.container {
-  margin: 0 0 $spacing-03 $spacing-05;
-  display: none;
-  box-shadow: 0 0 5px 2px $gray-40;
-}
-
-.filters {
-  padding: $spacing-05;
-  display: flex;
-  align-items: baseline;
-  column-gap: $spacing-09;
-}
-
-.visible {
+.page {
   display: flex;
   flex-direction: column;
-  animation: fade-in 0.5s;
 }
 
-@keyframes fade-in {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
+.actionButtons {
+  margin: $spacing-03 0;
+  display: flex;
+  column-gap: $spacing-03;
 }
 
-.filterSelector {
-  max-width: 25%;
+.containerWarning {
+  display: flex;
+  column-gap: $spacing-03;
+  align-items: center;
+  color: var(--cds-support-warning);
+  font-size: 14px;
+  line-height: 16px;
 }

--- a/src/components/expression-builder/ExpressionBuilder.tsx
+++ b/src/components/expression-builder/ExpressionBuilder.tsx
@@ -1,0 +1,143 @@
+/**
+ *
+ * Copyright 2023-2024 InspectorRAGet Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **/
+
+'use client';
+
+import { isEmpty } from 'lodash';
+import { useState, useEffect } from 'react';
+import { TextArea, Button } from '@carbon/react';
+import { WarningAlt } from '@carbon/icons-react';
+
+import { Model, Metric } from '@/src/types';
+import {
+  PLACHOLDER_EXPRESSION_TEXT,
+  validate,
+} from '@/src/utilities/expressions';
+
+import classes from './ExpressionBuilder.module.scss';
+
+// ===================================================================================
+//                                TYPES
+// ===================================================================================
+interface Props {
+  expression?: object;
+  models?: Model[];
+  metric?: Metric;
+  setExpression?: Function;
+}
+
+// ===================================================================================
+//                               MAIN FUNCTION
+// ===================================================================================
+export default function ExpressionBuilder({
+  expression,
+  models,
+  metric,
+  setExpression,
+}: Props) {
+  // Step 1: Initialize state and necessary variables
+  const [updatedExpressionText, setUpdatedExpressionText] = useState<string>(
+    expression ? JSON.stringify(expression) : PLACHOLDER_EXPRESSION_TEXT,
+  );
+  const [errorMessage, setErrorMessage] = useState<string>();
+
+  // Step 2: Run effects
+  // Step 2.a: Validate expression when updated
+  useEffect(() => {
+    try {
+      // Step 2.a: Check JSON validity
+      const updatedExpression = JSON.parse(updatedExpressionText);
+
+      // Step 2.b: Check expression validity
+      const errorMessage = validate(
+        updatedExpression,
+        models?.map((model) => model.modelId),
+      );
+      if (errorMessage) {
+        setErrorMessage(errorMessage);
+      } else {
+        setErrorMessage(undefined);
+      }
+    } catch (err) {
+      setErrorMessage('Invalid JSON');
+    }
+  }, [updatedExpressionText]);
+
+  return (
+    <div className={classes.page}>
+      <TextArea
+        labelText="Expression"
+        placeholder={JSON.stringify(expression)}
+        value={updatedExpressionText}
+        disabled={
+          models === undefined ||
+          metric === undefined ||
+          setExpression === undefined
+        }
+        invalid={errorMessage !== undefined}
+        invalidText={errorMessage}
+        onChange={(event) => {
+          setUpdatedExpressionText(event.target.value);
+        }}
+        helperText="Please make sure you select correct model ids and values"
+        rows={4}
+        id="text-area__expression"
+      />
+      <div className={classes.actionButtons}>
+        <Button
+          kind="primary"
+          disabled={
+            errorMessage !== undefined ||
+            models === undefined ||
+            metric === undefined ||
+            setExpression === undefined
+          }
+          onClick={() =>
+            setExpression
+              ? setExpression(JSON.parse(updatedExpressionText))
+              : () => {}
+          }
+        >
+          Run
+        </Button>
+        <Button
+          kind="secondary"
+          disabled={expression === undefined || isEmpty(expression)}
+          onClick={() => {
+            // Step 1: Reset updated expression text
+            setUpdatedExpressionText('{}');
+
+            // Step 2: Reset expression
+            if (setExpression) {
+              setExpression({});
+            }
+          }}
+        >
+          Clear
+        </Button>
+      </div>
+
+      {models === undefined || metric === undefined ? (
+        <div className={classes.containerWarning}>
+          <WarningAlt />
+          <span>You must select a metric before proceeding.</span>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/filters/Filters.tsx
+++ b/src/components/filters/Filters.tsx
@@ -22,10 +22,22 @@ import { isEmpty, omit } from 'lodash';
 import cx from 'classnames';
 import { useState, useEffect } from 'react';
 
-import { FilterableMultiSelect, Tag, Tooltip, Button } from '@carbon/react';
+import {
+  FilterableMultiSelect,
+  Tag,
+  Tooltip,
+  Button,
+  Tabs,
+  TabList,
+  Tab,
+  TabPanels,
+  TabPanel,
+} from '@carbon/react';
 import { ChevronUp, ChevronDown, Filter } from '@carbon/icons-react';
+import ExpressionBuilder from '@/src/components/expression-builder/ExpressionBuilder';
 
 import classes from './Filters.module.scss';
+import { Metric, Model } from '@/src/types';
 
 // ===================================================================================
 //                                TYPES
@@ -35,6 +47,10 @@ interface Props {
   filters: { [key: string]: string[] };
   selectedFilters: { [key: string]: string[] };
   setSelectedFilters: Function;
+  models?: Model[];
+  metric?: Metric;
+  expression?: object;
+  setExpression?: Function;
 }
 
 // ===================================================================================
@@ -45,6 +61,10 @@ export default function Filters({
   filters,
   selectedFilters,
   setSelectedFilters,
+  models,
+  metric,
+  expression,
+  setExpression,
 }: Props) {
   // Step 1: Initialize state and necessary variables
   const [showFilters, setShowFilters] = useState<boolean>(true);
@@ -52,7 +72,7 @@ export default function Filters({
   // Step 2: Run effects
   // Step 2.a: If no filters are found, set show filters to false
   useEffect(() => {
-    if (filters === undefined) {
+    if (filters === undefined && setExpression === undefined) {
       setShowFilters(false);
     }
   }, [filters]);
@@ -90,48 +110,123 @@ export default function Filters({
           </Button>
         </Tooltip>
       )}
-      <div className={cx(classes.filters, showFilters && classes.visible)}>
-        {showFilters &&
-          filters &&
-          Object.entries(filters).map(([filterType, values]) => {
-            return (
-              <div
-                key={`${keyPrefix}-filter` + filterType + '-selector'}
-                className={classes.filterSelector}
-              >
-                <FilterableMultiSelect
-                  id={`${keyPrefix}-filter` + filterType + '-selector'}
-                  titleText={filterType}
-                  items={values}
-                  itemToString={(item) => String(item)}
-                  onChange={(event) => {
-                    setSelectedFilters((prevState) =>
-                      isEmpty(event.selectedItems)
-                        ? omit(prevState, filterType)
-                        : {
-                            ...prevState,
-                            [filterType]: event.selectedItems,
-                          },
-                    );
-                  }}
-                ></FilterableMultiSelect>
-                {Object.keys(selectedFilters).includes(filterType) ? (
-                  <div>
-                    {selectedFilters[filterType].map((value) => {
+      <div className={cx(classes.container, showFilters && classes.visible)}>
+        {showFilters ? (
+          filters && expression ? (
+            <Tabs>
+              <TabList aria-label="additional filters" contained fullWidth>
+                <Tab>Static</Tab>
+                <Tab>
+                  Expression <Tag type="green">Experimental</Tag>
+                </Tab>
+              </TabList>
+              <TabPanels>
+                <TabPanel>
+                  <div className={classes.filters}>
+                    {Object.entries(filters).map(([filterType, values]) => {
                       return (
-                        <Tag
-                          type={'cool-gray'}
-                          key={`${keyPrefix}-filter-value` + value}
+                        <div
+                          key={`${keyPrefix}-filter` + filterType + '-selector'}
+                          className={classes.filterSelector}
                         >
-                          {value}
-                        </Tag>
+                          <FilterableMultiSelect
+                            id={
+                              `${keyPrefix}-filter` + filterType + '-selector'
+                            }
+                            titleText={filterType}
+                            items={values}
+                            itemToString={(item) => String(item)}
+                            onChange={(event) => {
+                              setSelectedFilters((prevState) =>
+                                isEmpty(event.selectedItems)
+                                  ? omit(prevState, filterType)
+                                  : {
+                                      ...prevState,
+                                      [filterType]: event.selectedItems,
+                                    },
+                              );
+                            }}
+                          ></FilterableMultiSelect>
+                          {Object.keys(selectedFilters).includes(filterType) ? (
+                            <div>
+                              {selectedFilters[filterType].map((value) => {
+                                return (
+                                  <Tag
+                                    type={'cool-gray'}
+                                    key={`${keyPrefix}-filter-value` + value}
+                                  >
+                                    {value}
+                                  </Tag>
+                                );
+                              })}
+                            </div>
+                          ) : null}
+                        </div>
                       );
                     })}
                   </div>
-                ) : null}
-              </div>
-            );
-          })}
+                </TabPanel>
+                <TabPanel>
+                  <ExpressionBuilder
+                    expression={expression}
+                    models={models}
+                    metric={metric}
+                    setExpression={setExpression}
+                  ></ExpressionBuilder>
+                </TabPanel>
+              </TabPanels>
+            </Tabs>
+          ) : filters ? (
+            <div className={classes.filters}>
+              {Object.entries(filters).map(([filterType, values]) => {
+                return (
+                  <div
+                    key={`${keyPrefix}-filter` + filterType + '-selector'}
+                    className={classes.filterSelector}
+                  >
+                    <FilterableMultiSelect
+                      id={`${keyPrefix}-filter` + filterType + '-selector'}
+                      titleText={filterType}
+                      items={values}
+                      itemToString={(item) => String(item)}
+                      onChange={(event) => {
+                        setSelectedFilters((prevState) =>
+                          isEmpty(event.selectedItems)
+                            ? omit(prevState, filterType)
+                            : {
+                                ...prevState,
+                                [filterType]: event.selectedItems,
+                              },
+                        );
+                      }}
+                    ></FilterableMultiSelect>
+                    {Object.keys(selectedFilters).includes(filterType) ? (
+                      <div>
+                        {selectedFilters[filterType].map((value) => {
+                          return (
+                            <Tag
+                              type={'cool-gray'}
+                              key={`${keyPrefix}-filter-value` + value}
+                            >
+                              {value}
+                            </Tag>
+                          );
+                        })}
+                      </div>
+                    ) : null}
+                  </div>
+                );
+              })}
+            </div>
+          ) : expression ? (
+            <ExpressionBuilder
+              expression={expression}
+              models={models}
+              metric={metric}
+              setExpression={setExpression}
+            ></ExpressionBuilder>
+          ) : null
+        ) : null}
       </div>
     </>
   );

--- a/src/utilities/expressions.ts
+++ b/src/utilities/expressions.ts
@@ -1,0 +1,340 @@
+/**
+ *
+ * Copyright 2023-2024 InspectorRAGet Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **/
+
+import { isEmpty, intersectionWith, unionWith, isEqual } from 'lodash';
+import { Metric, TaskEvaluation } from '@/src/types';
+import { castToNumber } from '@/src/utilities/metrics';
+
+// ===================================================================================
+//                                CONSTANTS
+// ===================================================================================
+export const PLACHOLDER_EXPRESSION_TEXT = '{}';
+export enum EXPRESSION_OPERATORS {
+  // Logical operators
+  AND = '$and',
+  OR = '$or',
+
+  // Comparison operators
+  EQ = '$eq',
+  NEQ = '$neq',
+  GT = '$gt',
+  GTE = '$gte',
+  LT = '$lt',
+  LTE = '$lte',
+}
+
+export function validate(
+  expression: object,
+  modelIds?: string[],
+  values?: (string | number)[],
+  parent?: string,
+): string | null {
+  // Step 1: Identify all the keys
+  const keys = Object.keys(expression);
+
+  // Step 2: In case of operator presence
+  const operators = keys.filter((key) => key.startsWith('$'));
+  if (operators.length > 1) {
+    return `More than one operator [${operators.join(', ')}] on the same level in the expression`;
+  }
+
+  if (operators.length === 1 && keys.length > 1) {
+    return `Additional keys on the same level in the expression`;
+  }
+
+  if (operators.length === 1) {
+    const operator = operators[0];
+
+    // Logical operator condition
+    if (
+      operator === EXPRESSION_OPERATORS.AND ||
+      operator === EXPRESSION_OPERATORS.OR
+    ) {
+      if (parent && modelIds && modelIds.includes(parent)) {
+        return `Logical operator ("${operator}") must not preceed with model ID`;
+      }
+
+      if (
+        !Array.isArray(expression[operator]) ||
+        expression[operator].some((value) => typeof value !== 'object')
+      ) {
+        return `Logical operator ("${operator}") must follow with array of expressions`;
+      }
+
+      if (
+        isEmpty(expression[operator]) ||
+        expression[operator].some((entry) => isEmpty(entry))
+      ) {
+        return `Logical operator ("${operator}") cannot have empty expression value`;
+      }
+
+      for (let index = 0; index < expression[operator].length; index++) {
+        const nestedErrorMessage = validate(
+          expression[operator][index],
+          modelIds,
+        );
+        if (nestedErrorMessage) {
+          return nestedErrorMessage;
+        }
+      }
+    }
+    // Comparison operators condition
+    else if (
+      operator === EXPRESSION_OPERATORS.EQ ||
+      operator === EXPRESSION_OPERATORS.NEQ ||
+      operator === EXPRESSION_OPERATORS.LT ||
+      operator === EXPRESSION_OPERATORS.LTE ||
+      operator === EXPRESSION_OPERATORS.GT ||
+      operator === EXPRESSION_OPERATORS.GTE
+    ) {
+      if (parent === undefined || parent.startsWith('$')) {
+        return `Comparison operator ("${operator}") must preceed with model ID`;
+      }
+      if (
+        typeof expression[operator] !== 'string' &&
+        typeof expression[operator] !== 'number'
+      ) {
+        return `Comparison operator ("${operator}") must follow primitive data types ("string" or "number")`;
+      }
+    }
+  } else {
+    // Step 3: In case of operator less expression
+    for (let idx = 0; idx < keys.length; idx++) {
+      // Step 3.a: If model IDs are provided, make sure key is one of those model IDs
+      if (modelIds && !modelIds.includes(keys[idx])) {
+        return `Model ("${keys[idx]}") does not exists. Please use one for the following models: ${modelIds.join(', ')}`;
+      }
+
+      const value = expression[keys[idx]];
+      if (
+        typeof value !== 'object' &&
+        typeof value !== 'string' &&
+        typeof value !== 'number'
+      ) {
+        return `Model ("${keys[idx]}") must follow either expression or primitive data types ("string" or "number")`;
+      }
+
+      if (typeof value === 'object') {
+        const nestedErrorMessage = validate(
+          expression[keys[idx]],
+          modelIds,
+          values,
+          keys[idx],
+        );
+        if (nestedErrorMessage) {
+          return nestedErrorMessage;
+        }
+      } else {
+        if (values && !values.includes(value)) {
+          return `"${value}" is not a valid value option. Please use one of the following: ${values.join(', ')}`;
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+export function evaluate(
+  evaluationsPerTaskPerModel: {
+    [key: string]: { [key: string]: TaskEvaluation };
+  },
+  expression: object,
+  metric: Metric,
+  annotator?: string,
+): TaskEvaluation[] {
+  // Step 1: Initialize necessary variables
+  const eligibleEvaluations: TaskEvaluation[] = [];
+
+  // Step 2: Identify all the keys
+  const keys = Object.keys(expression);
+
+  // Step 3: In case of operator presence
+  const operators = keys.filter((key) => key.startsWith('$'));
+  if (operators.length === 1) {
+    const operator = operators[0];
+
+    // Step 3.a: In case of a logical operator
+    if (
+      operator === EXPRESSION_OPERATORS.AND ||
+      operator === EXPRESSION_OPERATORS.OR
+    ) {
+      // Step 3.a.i: Initialize necessary variables
+      const results: TaskEvaluation[][] = [];
+
+      // Step 3.a.ii: Identify evaluations meeting nested expression
+      expression[operator].forEach((condition) => {
+        results.push(
+          evaluate(evaluationsPerTaskPerModel, condition, metric, annotator),
+        );
+      });
+
+      // Step 3.a.iii: Apply intersection ('$and') or union ('$or') logic based on the logical operator
+      if (operator === EXPRESSION_OPERATORS.AND) {
+        return intersectionWith(...results, isEqual);
+      } else {
+        return unionWith(...results, isEqual);
+      }
+    }
+  } else {
+    // Step 3: In case of expression without logical operators
+    // Step 3.a: Iterate over evaluations for each task
+    Object.values(evaluationsPerTaskPerModel).forEach((evaluationPerModel) => {
+      // Step 3.a.i: Initialize necessary variables
+      let satisfy: boolean = true;
+
+      // Step 3.a.ii: Iterate over conditions for each model in the expression
+      for (let idx = 0; idx < keys.length; idx++) {
+        // Step 3.a.ii.*: Check if evaluation exists
+        if (!evaluationPerModel.hasOwnProperty(keys[idx])) {
+          satisfy = false;
+          break;
+        }
+
+        // Step 3.a.ii.**: Fetch evaluation, value and expected value condition
+        const evaluation = evaluationPerModel[keys[idx]];
+
+        // Step 3.a.ii.***: Calculate value
+        /**
+         * annotator specific value if annotator is specified
+         * OR
+         * aggregate value
+         */
+        let value: string | number;
+        if (annotator) {
+          if (!evaluation[metric.name].hasOwnProperty(annotator)) {
+            satisfy = false;
+            break;
+          }
+          value = castToNumber(
+            evaluation[metric.name][annotator].value,
+            metric.values,
+          );
+        } else {
+          value = castToNumber(
+            evaluation[`${metric.name}_agg`].value,
+            metric.values,
+          );
+        }
+
+        // Step 3.a.ii.*****: Extract expection from expression
+        const expectation = expression[keys[idx]];
+
+        // Step 3.a.ii.******: In case of expectation is an expression
+        if (typeof expectation === 'object') {
+          // Extract comparison operator from expectation expression
+          const operator = Object.keys(expectation).filter((key) =>
+            key.startsWith('$'),
+          )[0];
+
+          // If comparison operator is "$gt" OR "$gte"
+          if (
+            (operator === EXPRESSION_OPERATORS.GTE ||
+              operator === EXPRESSION_OPERATORS.GT) &&
+            (isNaN(value) ||
+              value <
+                castToNumber(
+                  expectation[operator],
+                  metric.values,
+                  typeof expectation[operator] === 'string'
+                    ? 'displayValue'
+                    : 'value',
+                ))
+          ) {
+            satisfy = false;
+            break;
+          }
+
+          // If comparison operator is "$lt" OR "$lte"
+          if (
+            (operator === EXPRESSION_OPERATORS.LTE ||
+              operator === EXPRESSION_OPERATORS.LT) &&
+            (isNaN(value) ||
+              value >
+                castToNumber(
+                  expectation[operator],
+                  metric.values,
+                  typeof expectation[operator] === 'string'
+                    ? 'displayValue'
+                    : 'value',
+                ))
+          ) {
+            satisfy = false;
+            break;
+          }
+
+          // If comparison operator is "$eq"
+          if (
+            operator === EXPRESSION_OPERATORS.EQ &&
+            (isNaN(value) ||
+              value !==
+                castToNumber(
+                  expectation[operator],
+                  metric.values,
+                  typeof expectation[operator] === 'string'
+                    ? 'displayValue'
+                    : 'value',
+                ))
+          ) {
+            satisfy = false;
+            break;
+          }
+
+          // If comparison operator is "$neq"
+          if (
+            operator === EXPRESSION_OPERATORS.NEQ &&
+            (isNaN(value) ||
+              value ===
+                castToNumber(
+                  expectation[operator],
+                  metric.values,
+                  typeof expectation[operator] === 'string'
+                    ? 'displayValue'
+                    : 'value',
+                ))
+          ) {
+            satisfy = false;
+            break;
+          }
+        } else {
+          // 3.a.ii.******: In case of expectation is a primitive type ("string"/"number") value
+          if (
+            isNaN(value) ||
+            value !==
+              castToNumber(
+                expectation,
+                metric.values,
+                typeof expectation === 'string' ? 'displayValue' : 'value',
+              )
+          ) {
+            satisfy = false;
+            break;
+          }
+        }
+      }
+
+      // Step 3.a.iii: If satisfy expression requirments, add all evaluations for the current task to eligible evaluations list
+      if (satisfy) {
+        eligibleEvaluations.push(...Object.values(evaluationPerModel));
+      }
+    });
+  }
+
+  // Step 4: Return
+  return eligibleEvaluations;
+}

--- a/src/utilities/metrics.ts
+++ b/src/utilities/metrics.ts
@@ -80,13 +80,16 @@ export function extractMetricDisplayName(metric: Metric): string {
 export function castToNumber(
   value: string | number,
   references?: MetricValue[],
+  key?: 'value' | 'displayValue',
 ): number {
   // If value is of type "string"
   if (typeof value === 'string') {
     // Step 1: Check if references are provided to convert "string" value to "numeric" value
     if (references) {
       // Step 1.a: Find appropriate reference by comparing "string" values
-      const reference = references.find((entry) => entry.value === value);
+      const reference = references.find((entry) =>
+        key ? entry[key] === value : entry.value === value,
+      );
 
       // Step 1.b: If numeric value exists in reference, then return it
       if (
@@ -96,7 +99,7 @@ export function castToNumber(
       ) {
         return reference.numericValue;
       } else {
-        return parseInt(value);
+        return parseFloat(value);
       }
     }
     // Step 2: Cast to int, if references are absent

--- a/src/views/tasks-table/TasksTable.tsx
+++ b/src/views/tasks-table/TasksTable.tsx
@@ -343,7 +343,58 @@ export default function TasksTable({
     <>
       {headers && rows && (
         <div>
-          <DataTable rows={visibleRows} headers={headers} isSortable>
+          <DataTable
+            rows={visibleRows}
+            headers={headers}
+            isSortable
+            sortRow={(cellA, cellB, { sortDirection, sortStates }) => {
+              // Step 1: Check if cell values are objects
+              if (typeof cellA === 'object' && typeof cellB === 'object') {
+                // Step 1.a: Get first value for each cell object
+                const valueA = Object.values(cellA)[0];
+                const valueB = Object.values(cellB)[0];
+
+                // Step 1.b: Check if both values are of "string" type
+                if (typeof valueA === 'string' && typeof valueB === 'string') {
+                  // Step 1.b.i: Check if both values are purely numeric
+                  if (
+                    !isNaN(parseFloat(valueA)) &&
+                    !isNaN(parseFloat(valueB))
+                  ) {
+                    if (sortDirection === sortStates.DESC) {
+                      return parseFloat(valueA) - parseFloat(valueB);
+                    }
+                    return parseFloat(valueB) - parseFloat(valueA);
+                  } else {
+                    if (sortDirection === sortStates.DESC) {
+                      return valueA.localeCompare(valueB);
+                    }
+
+                    return valueB.localeCompare(valueA);
+                  }
+                }
+                // Step 1.c: Check if both values are of "number" type
+                else if (
+                  typeof valueA === 'number' &&
+                  typeof valueB === 'number'
+                ) {
+                  if (sortDirection === sortStates.DESC) {
+                    return valueA - valueB;
+                  }
+
+                  return valueB - valueA;
+                }
+              }
+              // Step 2: cell values are assumed to be of "string" type
+              else {
+                if (sortDirection === sortStates.DESC) {
+                  return cellA.localeCompare(cellB);
+                }
+
+                return cellB.localeCompare(cellA);
+              }
+            }}
+          >
             {({
               rows,
               headers,


### PR DESCRIPTION
- Allow user to specify custom expression to filter visible evaluations in model behavior tab.
- Supports `$and`, `$or`, `$lt`, `$lte`, `$gt`, `$gte`, `$eq` and `$neq` operators
- Fix broken sorting on task table
- Allow application to be embedded into iframe from different ancestor


sample expressions:
```JSON
{"$and/$or": [{"model_id_a": "value"}, {"model_id_b": {"$lt/$lte/...": "value"}}]}
```

```JSON
{"model_id_a": "value", "model_id_b": "value"}
```