### PR TITLE
feat: add ModelCharacteristics view and fix BFCL converter data quality

### DIFF
--- a/converters/bfcl/README.md
+++ b/converters/bfcl/README.md
@@ -174,7 +174,6 @@ Source URLs:
 | -------------------------- | ----------- | ---------- | ----------------------------------------------------------------------------------------- |
 | `bfcl_correctness`         | categorical | majority   | Binary pass/fail: `correct` (1) or `incorrect` (0)                                        |
 | `bfcl_error_severity`      | categorical | majority   | Recoverability-anchored severity score (see scale below)                                  |
-| `bfcl_error_type`          | text        |            | Raw BFCL error type string (e.g., `type_error:nested`); `"none"` for correct tasks        |
 | `bfcl_errors`              | text        |            | Full error messages from BFCL, joined as a single string; `"none"` for correct tasks      |
 | `bfcl_latency_total_s`     | numerical   | mean       | Wall-clock inference time in seconds                                                      |
 | `bfcl_input_tokens_total`  | numerical   | mean       | Total input token count (not directly comparable across models with different tokenizers) |
@@ -182,27 +181,39 @@ Source URLs:
 
 ### Error Severity Scale
 
-| Value               | Score | Meaning                                                    | BFCL Source                                           |
-| ------------------- | ----- | ---------------------------------------------------------- | ----------------------------------------------------- |
-| `correct`           | 0.0   | No error                                                   | `valid: true`                                         |
-| `wrong_arguments`   | 0.25  | Right function, wrong argument values or types             | `type_error:*`, `value_error:*`, `missing_optional`   |
-| `wrong_function`    | 0.5   | Called the wrong function or wrong number of functions     | `wrong_func_name`, `wrong_count`, `cannot_find_match` |
-| `unknown`           | 0.5   | Error type not in the known mapping                        | Any unrecognised `error_type`                         |
-| `irrelevance_error` | 0.75  | Called a function when none was appropriate, or vice versa | `irrelevance_error:decoder_success`                   |
-| `malformed_output`  | 1.0   | Output could not be decoded into any function call         | No `model_result_decoded`                             |
+| Value               | Score | Meaning                                                    | BFCL Source                                                                                 |
+| ------------------- | ----- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `correct`           | 0.0   | No error                                                   | `valid: true`                                                                               |
+| `wrong_arguments`   | 0.25  | Right function, wrong argument values or types             | `type_error:*`, `value_error:*`, `missing_optional`, `missing_required`, `unexpected_param` |
+| `wrong_function`    | 0.5   | Called the wrong function or wrong number of functions     | `wrong_func_name`, `wrong_count`, `cannot_find_match`                                       |
+| `unknown`           | 0.5   | Error type not in the known mapping                        | Any `error_type` not listed above                                                           |
+| `irrelevance_error` | 0.75  | Called a function when none was appropriate, or vice versa | `irrelevance_error:decoder_success`                                                         |
+| `malformed_output`  | 1.0   | Output could not be decoded into any function call         | No `model_result_decoded`; `ast_decoder:*`; `relevance_error:decoder_failed`                |
+
+### Labels
+
+InspectorRAGet labels are per-(task, model) nominal descriptors that characterise output without scoring it. They have no ordering or aggregation semantics and appear in the Model Characteristics tab as grouped bar charts showing distribution across models.
+
+| Label        | Description                                                                                                |
+| ------------ | ---------------------------------------------------------------------------------------------------------- |
+| `Error Type` | Categorical error classifier for each result; `"none"` for correct tasks, `"N/A"` if error type is unknown |
+
+`error_type` is a label rather than a metric because it is a categorical classifier with no natural ordering or aggregation. Using it as a metric would imply ordinal meaning that does not exist. As a label it enables distribution analysis across models in Model Characteristics — the question researchers actually want to answer is "which error categories appear most often for this model?" not "what is the average error type?"
+
+For single-turn tasks, `Error Type` values are raw BFCL strings such as `type_error:nested`, `wrong_func_name`, `irrelevance_error:decoder_success`, and `none`. For multi-turn tasks, see the table below.
 
 ### Multi-Turn Error Types
 
-For agentic tasks, `bfcl_error_type` uses `multi_turn:` prefixed values:
+For agentic tasks, the `Error Type` label uses the raw BFCL `error_type` string with the `multi_turn:` prefix stripped (e.g., `instance_state_mismatch` instead of `multi_turn:instance_state_mismatch`). The agentic context is implied by the dataset.
 
-| Error Type                               | Severity                 | Meaning                                                                                                         |
-| ---------------------------------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| `none`                                   | `correct` (0.0)          | Task completed successfully                                                                                     |
-| `multi_turn:execution_response_mismatch` | `wrong_arguments` (0.25) | Right function(s) but environment responses differed from ground truth                                          |
-| `multi_turn:instance_state_mismatch`     | `wrong_function` (0.5)   | Final environment state does not match ground truth                                                             |
-| `multi_turn:empty_turn_model_response`   | `malformed_output` (1.0) | Model produced no tool calls for a turn that required them                                                      |
-| `multi_turn:force_terminated`            | `malformed_output` (1.0) | Runner hit the 20-step budget cap (step budget exhausted across all turns, or too many retries within one turn) |
-| `multi_turn:inference_error`             | `malformed_output` (1.0) | Inference failure (e.g., context overflow, API error) during the run                                            |
+| Error Type (label value)      | Severity (`bfcl_error_severity`) | Meaning                                                                                                         |
+| ----------------------------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `none`                        | `correct` (0.0)                  | Task completed successfully                                                                                     |
+| `execution_response_mismatch` | `wrong_arguments` (0.25)         | Right function(s) but environment responses differed from ground truth                                          |
+| `instance_state_mismatch`     | `wrong_function` (0.5)           | Final environment state does not match ground truth                                                             |
+| `empty_turn_model_response`   | `malformed_output` (1.0)         | Model produced no tool calls for a turn that required them                                                      |
+| `force_terminated`            | `malformed_output` (1.0)         | Runner hit the 20-step budget cap (step budget exhausted across all turns, or too many retries within one turn) |
+| `inference_error`             | `malformed_output` (1.0)         | Inference failure (e.g., context overflow, API error) during the run                                            |
 
 ---
 
@@ -277,12 +288,12 @@ BFCL's ground truth is a list where every element is a required parallel call (A
 
 InspectorRAGet requires every model to have a score for every metric on every task. When a task failed for one model but passed for another, the converter synthesises "correct" scores for the passing model:
 
-| Metric                 | Failing Model             | Passing Model                          |
+| Metric / Label         | Failing Model             | Passing Model                          |
 | ---------------------- | ------------------------- | -------------------------------------- |
 | `bfcl_error_severity`  | derived from `error_type` | `correct` / `0.0`                      |
-| `bfcl_error_type`      | raw error type string     | `"none"`                               |
 | `bfcl_errors`          | error messages joined     | `"none"`                               |
 | `bfcl_latency_total_s` | from result file          | from result file, or `600.0` if absent |
+| `Error Type` (label)   | raw error type string     | `"none"`                               |
 
 The `600.0` sentinel for missing latency (10 minutes) is intentionally large — it stands out in aggregate views and signals incomplete data rather than silently skewing the mean.
 

--- a/converters/bfcl/convert.py
+++ b/converters/bfcl/convert.py
@@ -110,24 +110,77 @@ SEVERITY_MAP = {
     "value_error:others": ("wrong_arguments", 0.25, "Wrong Arguments"),
     "value_error:list/tuple": ("wrong_arguments", 0.25, "Wrong Arguments"),
     "value_error:dict_value": ("wrong_arguments", 0.25, "Wrong Arguments"),
-    "simple_function_checker:missing_optional": ("wrong_arguments", 0.25, "Wrong Arguments"),
+    "value_error:dict_key": ("wrong_arguments", 0.25, "Wrong Arguments"),
+    "value_error:list_dict_count": ("wrong_arguments", 0.25, "Wrong Arguments"),
+    "simple_function_checker:missing_optional": (
+        "wrong_arguments",
+        0.25,
+        "Wrong Arguments",
+    ),
+    "simple_function_checker:missing_required": (
+        "wrong_arguments",
+        0.25,
+        "Wrong Arguments",
+    ),
+    "simple_function_checker:unexpected_param": (
+        "wrong_arguments",
+        0.25,
+        "Wrong Arguments",
+    ),
+    # Java/JavaScript type vocabulary errors — argument-level mismatch.
+    "type_error:java": ("wrong_arguments", 0.25, "Wrong Arguments"),
+    "type_error:js": ("wrong_arguments", 0.25, "Wrong Arguments"),
     # --- Single-turn: function-level errors ---
-    "simple_function_checker:wrong_func_name": ("wrong_function", 0.50, "Wrong Function"),
+    "simple_function_checker:wrong_func_name": (
+        "wrong_function",
+        0.50,
+        "Wrong Function",
+    ),
     "simple_function_checker:wrong_count": ("wrong_function", 0.50, "Wrong Function"),
     "multiple_function_checker:wrong_count": ("wrong_function", 0.50, "Wrong Function"),
-    "parallel_function_checker_no_order:wrong_count": ("wrong_function", 0.50, "Wrong Function"),
-    "parallel_function_checker_no_order:cannot_find_match": ("wrong_function", 0.50, "Wrong Function"),
+    "parallel_function_checker_no_order:wrong_count": (
+        "wrong_function",
+        0.50,
+        "Wrong Function",
+    ),
+    "parallel_function_checker_no_order:cannot_find_match": (
+        "wrong_function",
+        0.50,
+        "Wrong Function",
+    ),
+    # --- Single-turn: malformed output ---
+    # AST decoder could not parse the model's output into any function call at all.
+    "ast_decoder:decoder_failed": ("malformed_output", 1.0, "Malformed Output"),
+    "ast_decoder:decoder_wrong_output_format": (
+        "malformed_output",
+        1.0,
+        "Malformed Output",
+    ),
+    # Relevance checker decoder failure — output could not be decoded for irrelevance check.
+    "relevance_error:decoder_failed": ("malformed_output", 1.0, "Malformed Output"),
     # --- Single-turn: irrelevance errors ---
-    "irrelevance_error:decoder_success": ("irrelevance_error", 0.75, "Irrelevance Error"),
+    "irrelevance_error:decoder_success": (
+        "irrelevance_error",
+        0.75,
+        "Irrelevance Error",
+    ),
     # --- Multi-turn: argument/execution errors ---
     # Model called the right function but with wrong arguments; execution failed.
-    "multi_turn:execution_response_mismatch": ("wrong_arguments", 0.25, "Wrong Arguments"),
+    "multi_turn:execution_response_mismatch": (
+        "wrong_arguments",
+        0.25,
+        "Wrong Arguments",
+    ),
     # --- Multi-turn: state/function errors ---
     # Model completed all turns but the environment ended in the wrong state.
     "multi_turn:instance_state_mismatch": ("wrong_function", 0.50, "Wrong Function"),
     # --- Multi-turn: unrecoverable failures ---
     # Model produced no output for a turn, ran out of turns, or output couldn't be decoded.
-    "multi_turn:empty_turn_model_response": ("malformed_output", 1.0, "Malformed Output"),
+    "multi_turn:empty_turn_model_response": (
+        "malformed_output",
+        1.0,
+        "Malformed Output",
+    ),
     "multi_turn:force_terminated": ("malformed_output", 1.0, "Malformed Output"),
     "multi_turn:inference_error": ("malformed_output", 1.0, "Malformed Output"),
 }
@@ -136,6 +189,7 @@ SEVERITY_MAP = {
 # ---------------------------------------------------------------------------
 # Tool definition normalisation
 # ---------------------------------------------------------------------------
+
 
 def normalize_tool_def(tool: dict) -> dict:
     """
@@ -151,7 +205,10 @@ def normalize_tool_def(tool: dict) -> dict:
         elif isinstance(value, dict):
             result[key] = normalize_tool_def(value)
         elif isinstance(value, list):
-            result[key] = [normalize_tool_def(item) if isinstance(item, dict) else item for item in value]
+            result[key] = [
+                normalize_tool_def(item) if isinstance(item, dict) else item
+                for item in value
+            ]
         else:
             result[key] = value
     return result
@@ -160,6 +217,7 @@ def normalize_tool_def(tool: dict) -> dict:
 # ---------------------------------------------------------------------------
 # Ground-truth (possible_answer) → TaskTarget conversion
 # ---------------------------------------------------------------------------
+
 
 def possible_answer_to_targets(possible_answer: list) -> list:
     """
@@ -204,12 +262,16 @@ def possible_answer_to_targets(possible_answer: list) -> list:
                     else:
                         canonical_args[arg_name] = arg_values
 
-            calls.append({"id": call_id, "name": func_name, "arguments": canonical_args})
+            calls.append(
+                {"id": call_id, "name": func_name, "arguments": canonical_args}
+            )
 
             # If any argument has more than one acceptable value, record the
             # additional combinations in alternatives keyed by this call's id.
             if isinstance(args, dict):
-                extra_values = {k: v for k, v in args.items() if isinstance(v, list) and len(v) > 1}
+                extra_values = {
+                    k: v for k, v in args.items() if isinstance(v, list) and len(v) > 1
+                }
                 if extra_values:
                     alt_calls = []
                     # Generate one ToolCallRecord per additional combination.
@@ -221,7 +283,13 @@ def possible_answer_to_targets(possible_answer: list) -> list:
                         for arg_name, arg_values in extra_values.items():
                             if i < len(arg_values):
                                 alt_args[arg_name] = arg_values[i]
-                        alt_calls.append({"id": str(uuid.uuid4()), "name": func_name, "arguments": alt_args})
+                        alt_calls.append(
+                            {
+                                "id": str(uuid.uuid4()),
+                                "name": func_name,
+                                "arguments": alt_args,
+                            }
+                        )
                     if alt_calls:
                         alternatives[call_id] = alt_calls
 
@@ -234,6 +302,7 @@ def possible_answer_to_targets(possible_answer: list) -> list:
 # ---------------------------------------------------------------------------
 # Model output → Message[] conversion
 # ---------------------------------------------------------------------------
+
 
 def decoded_to_tool_calls(model_result_decoded) -> list | None:
     """
@@ -249,11 +318,13 @@ def decoded_to_tool_calls(model_result_decoded) -> list | None:
         if not isinstance(entry, dict):
             continue
         for func_name, args in entry.items():
-            calls.append({
-                "id": str(uuid.uuid4()),
-                "name": func_name,
-                "arguments": args if isinstance(args, dict) else {},
-            })
+            calls.append(
+                {
+                    "id": str(uuid.uuid4()),
+                    "name": func_name,
+                    "arguments": args if isinstance(args, dict) else {},
+                }
+            )
 
     return calls if calls else None
 
@@ -261,6 +332,7 @@ def decoded_to_tool_calls(model_result_decoded) -> list | None:
 # ---------------------------------------------------------------------------
 # Token count helper
 # ---------------------------------------------------------------------------
+
 
 def token_sum(raw: int | float | list | None) -> float | None:
     """
@@ -281,7 +353,8 @@ def token_sum(raw: int | float | list | None) -> float | None:
     if isinstance(raw, (int, float)):
         return float(raw)
     total = sum(
-        v for inner in raw
+        v
+        for inner in raw
         for v in (inner if isinstance(inner, list) else [inner])
         if isinstance(v, (int, float))
     )
@@ -320,6 +393,7 @@ def model_token_averages(
 # Message status helper (item 22: metadata.status stamping)
 # ---------------------------------------------------------------------------
 
+
 def message_status_and_definition(msg: dict) -> tuple[str, str] | tuple[None, None]:
     """
     Derive a (status, statusDefinition) pair for a single message dict.
@@ -350,7 +424,10 @@ def message_status_and_definition(msg: dict) -> tuple[str, str] | tuple[None, No
             try:
                 parsed = json.loads(content)
                 if isinstance(parsed, dict) and "error" in parsed:
-                    return "fail", "Tool execution returned an error response from the BFCL environment."
+                    return (
+                        "fail",
+                        "Tool execution returned an error response from the BFCL environment.",
+                    )
             except (json.JSONDecodeError, ValueError):
                 pass
         return "pass", "Tool executed successfully and returned a result."
@@ -363,7 +440,9 @@ def message_status_and_definition(msg: dict) -> tuple[str, str] | tuple[None, No
         if trace:
             # Count intermediate invocation steps for a richer definition.
             invocation_count = sum(
-                1 for e in trace if isinstance(e, dict) and e.get("type") == "invocation"
+                1
+                for e in trace
+                if isinstance(e, dict) and e.get("type") == "invocation"
             )
             last_event = None
             for e in reversed(trace):
@@ -423,6 +502,7 @@ def message_status_and_definition(msg: dict) -> tuple[str, str] | tuple[None, No
 # Error metadata helper (item 23: ModelResult.metadata.error)
 # ---------------------------------------------------------------------------
 
+
 def build_error_metadata(error_dict: dict) -> dict | None:
     """
     Extract structured diagnostic detail from a multi-turn BFCL error dict and
@@ -449,13 +529,17 @@ def build_error_metadata(error_dict: dict) -> dict | None:
         context: dict = {}
         if "differences" in details:
             context["differences"] = details["differences"]
-        execution_result = error_dict.get("execution_result") or details.get("execution_result")
+        execution_result = error_dict.get("execution_result") or details.get(
+            "execution_result"
+        )
         if execution_result:
             context["execution_result"] = execution_result
         if context:
             return {"kind": "structured", "context": context}
 
-    if error_type == "multi_turn:execution_response_mismatch" and isinstance(details, dict):
+    if error_type == "multi_turn:execution_response_mismatch" and isinstance(
+        details, dict
+    ):
         context = {}
         if "missing_items" in details:
             context["missing_items"] = details["missing_items"]
@@ -469,10 +553,15 @@ def build_error_metadata(error_dict: dict) -> dict | None:
         if context:
             return {"kind": "structured", "context": context}
 
-    if error_type == "multi_turn:empty_turn_model_response" and isinstance(details, dict):
+    if error_type == "multi_turn:empty_turn_model_response" and isinstance(
+        details, dict
+    ):
         execution_result = details.get("execution_result")
         if execution_result:
-            return {"kind": "structured", "context": {"execution_result": execution_result}}
+            return {
+                "kind": "structured",
+                "context": {"execution_result": execution_result},
+            }
 
     return None
 
@@ -480,6 +569,7 @@ def build_error_metadata(error_dict: dict) -> dict | None:
 # ---------------------------------------------------------------------------
 # Error severity derivation
 # ---------------------------------------------------------------------------
+
 
 def derive_severity(valid: bool, error_type: str | None) -> tuple[str, float, str]:
     """
@@ -500,6 +590,7 @@ def derive_severity(valid: bool, error_type: str | None) -> tuple[str, float, st
 # File loading helpers
 # ---------------------------------------------------------------------------
 
+
 def load_jsonl(path: Path) -> list[dict]:
     """Load a JSONL file, skipping blank lines. Returns list of parsed objects."""
     records = []
@@ -510,7 +601,10 @@ def load_jsonl(path: Path) -> list[dict]:
                 try:
                     records.append(json.loads(line))
                 except json.JSONDecodeError as e:
-                    print(f"  Warning: skipping malformed line in {path}: {e}", file=sys.stderr)
+                    print(
+                        f"  Warning: skipping malformed line in {path}: {e}",
+                        file=sys.stderr,
+                    )
     return records
 
 
@@ -528,13 +622,14 @@ def infer_category(filename: str) -> str | None:
     # Strip version prefix (v4, v3, v2, v1)
     for prefix in ("BFCL_v4_", "BFCL_v3_", "BFCL_v2_", "BFCL_v1_"):
         if stem.startswith(prefix):
-            return stem[len(prefix):]
+            return stem[len(prefix) :]
     return None
 
 
 # ---------------------------------------------------------------------------
 # Directory scanning
 # ---------------------------------------------------------------------------
+
 
 def find_model_dirs(bfcl_root: Path) -> list[Path]:
     """
@@ -543,7 +638,9 @@ def find_model_dirs(bfcl_root: Path) -> list[Path]:
     """
     model_dirs = []
     for entry in sorted(bfcl_root.iterdir()):
-        if entry.is_dir() and ((entry / "result").exists() or (entry / "score").exists()):
+        if entry.is_dir() and (
+            (entry / "result").exists() or (entry / "score").exists()
+        ):
             model_dirs.append(entry)
     return model_dirs
 
@@ -578,7 +675,11 @@ def load_dataset_dir(dataset_dir: Path, categories: set[str]) -> dict[str, dict]
     """
     dataset_map: dict[str, dict] = {}
     for category in categories:
-        for pattern in (f"BFCL_v4_{category}.json", f"BFCL_v3_{category}.json", f"BFCL_v2_{category}.json"):
+        for pattern in (
+            f"BFCL_v4_{category}.json",
+            f"BFCL_v3_{category}.json",
+            f"BFCL_v2_{category}.json",
+        ):
             path = dataset_dir / pattern
             if not path.exists():
                 continue
@@ -594,7 +695,11 @@ def load_dataset_dir(dataset_dir: Path, categories: set[str]) -> dict[str, dict]
     answer_dir = dataset_dir / "possible_answer"
     if answer_dir.exists():
         for category in categories:
-            for pattern in (f"BFCL_v4_{category}.json", f"BFCL_v3_{category}.json", f"BFCL_v2_{category}.json"):
+            for pattern in (
+                f"BFCL_v4_{category}.json",
+                f"BFCL_v3_{category}.json",
+                f"BFCL_v2_{category}.json",
+            ):
                 path = answer_dir / pattern
                 if not path.exists():
                     continue
@@ -611,6 +716,7 @@ def load_dataset_dir(dataset_dir: Path, categories: set[str]) -> dict[str, dict]
 # ---------------------------------------------------------------------------
 # Core conversion: tool_calling task type
 # ---------------------------------------------------------------------------
+
 
 def convert_tool_calling(
     bfcl_root: Path,
@@ -634,7 +740,9 @@ def convert_tool_calling(
     if not model_dirs:
         sys.exit(f"Error: no model output directories found under {bfcl_root}")
 
-    print(f"Found {len(model_dirs)} model director{'y' if len(model_dirs) == 1 else 'ies'} under {bfcl_root}")
+    print(
+        f"Found {len(model_dirs)} model director{'y' if len(model_dirs) == 1 else 'ies'} under {bfcl_root}"
+    )
 
     for model_dir in model_dirs:
         print(f"\nProcessing: {model_dir.name}")
@@ -651,7 +759,10 @@ def convert_tool_calling(
                     deferred_categories.add(category)
                     continue
                 if category not in TOOL_CALLING_CATEGORIES:
-                    print(f"  Warning: unknown category '{category}' in {result_file.name}, skipping", file=sys.stderr)
+                    print(
+                        f"  Warning: unknown category '{category}' in {result_file.name}, skipping",
+                        file=sys.stderr,
+                    )
                     continue
 
                 records = load_jsonl(result_file)
@@ -680,10 +791,14 @@ def convert_tool_calling(
                     task_id = record.get("id")
                     if task_id:
                         score_map[model_id][task_id] = record
-                print(f"  Loaded {len(failure_records)} failure records from {score_file.name}")
+                print(
+                    f"  Loaded {len(failure_records)} failure records from {score_file.name}"
+                )
 
     if deferred_categories:
-        print(f"Deferred categories (multi-turn, agentic task type): {sorted(deferred_categories)}")
+        print(
+            f"Deferred categories (multi-turn, agentic task type): {sorted(deferred_categories)}"
+        )
         print("  Re-run with --task-type agentic to convert these.")
 
     # --- Load dataset files for passing-task prompts ---
@@ -693,8 +808,12 @@ def convert_tool_calling(
         print(f"\nLoaded {len(dataset_records)} task definitions from dataset dir")
     else:
         print("\nNo --dataset-dir provided.")
-        print("Output will contain only tasks that failed for at least one model (full prompt available from score files).")
-        print("To include passing tasks, download dataset files from https://huggingface.co/datasets/gorilla-llm/BFCL-v3")
+        print(
+            "Output will contain only tasks that failed for at least one model (full prompt available from score files)."
+        )
+        print(
+            "To include passing tasks, download dataset files from https://huggingface.co/datasets/gorilla-llm/BFCL-v3"
+        )
         print("and pass --dataset-dir.")
 
     # --- Determine which task IDs to emit ---
@@ -724,7 +843,9 @@ def convert_tool_calling(
 
     all_model_ids = sorted(result_map.keys())
     token_avgs = model_token_averages(result_map)
-    print(f"\nBuilding output for {len(task_ids_to_emit)} tasks across {len(all_model_ids)} model(s)...")
+    print(
+        f"\nBuilding output for {len(task_ids_to_emit)} tasks across {len(all_model_ids)} model(s)..."
+    )
 
     # --- Build tasks and results ---
     # tasks: flat list of task definitions (no model data).
@@ -813,7 +934,9 @@ def convert_tool_calling(
                 error_type = None
                 errors = []
 
-            severity_value, severity_numeric, severity_display = derive_severity(is_valid, error_type)
+            severity_value, severity_numeric, severity_display = derive_severity(
+                is_valid, error_type
+            )
 
             # Model output: decoded form from score record for failures.
             # For passing tasks the score file is absent, so BFCL provides no
@@ -821,7 +944,9 @@ def convert_tool_calling(
             # the model was correct, so its output matches the ground truth.
             # For failing tasks with no decoded output (e.g. inference errors),
             # fall back to the raw result string rather than the target proxy.
-            model_result_decoded = score_record.get("model_result_decoded") if score_record else None
+            model_result_decoded = (
+                score_record.get("model_result_decoded") if score_record else None
+            )
             tool_calls = decoded_to_tool_calls(model_result_decoded)
 
             # Build the output message. tool_calls takes priority; content is used
@@ -835,15 +960,22 @@ def convert_tool_calling(
                     if targets and targets[0].get("calls"):
                         output_message["tool_calls"] = targets[0]["calls"]
                 if "tool_calls" not in output_message:
-                    raw = (result_record or {}).get("result", "") or (score_record or {}).get("model_result_raw", "")
-                    output_message["content"] = raw if isinstance(raw, str) else json.dumps(raw)
+                    raw = (result_record or {}).get("result", "") or (
+                        score_record or {}
+                    ).get("model_result_raw", "")
+                    output_message["content"] = (
+                        raw if isinstance(raw, str) else json.dumps(raw)
+                    )
 
             # Stamp metadata.status and metadata.statusDefinition on the output
             # message so the UI can show a visual pass/fail/warn indicator with
             # a hover tooltip explaining the status.
             status, status_def = message_status_and_definition(output_message)
             if status:
-                output_message["metadata"] = {"status": status, "statusDefinition": status_def}
+                output_message["metadata"] = {
+                    "status": status,
+                    "statusDefinition": status_def,
+                }
 
             output = [output_message]
 
@@ -853,13 +985,17 @@ def convert_tool_calling(
             rec = result_record or {}
             latency = rec.get("latency", 600.0)
             avg = token_avgs.get(model_id, {})
-            input_tokens = token_sum(rec.get("input_token_count")) or avg.get("input", 0.0)
-            output_tokens = token_sum(rec.get("output_token_count")) or avg.get("output", 0.0)
+            input_tokens = token_sum(rec.get("input_token_count")) or avg.get(
+                "input", 0.0
+            )
+            output_tokens = token_sum(rec.get("output_token_count")) or avg.get(
+                "output", 0.0
+            )
 
             # Scores are nested as {metricName: {annotatorId: {value, ...}}}.
             # BFCL metrics are all algorithm-produced, annotator key is "bfcl".
             # All metrics are always present on every ModelResult.
-            # bfcl_error_type and bfcl_errors use "none" for passing models
+            # bfcl_errors use "none" for passing models
             # (unambiguously signals no error, not a missing value).
             scores: dict = {
                 "bfcl_correctness": {
@@ -875,26 +1011,34 @@ def convert_tool_calling(
                         "display_value": severity_display,
                     }
                 },
-                "bfcl_error_type": {
-                    "bfcl": {"value": error_type if error_type is not None else "none"}
-                },
                 "bfcl_errors": {
                     "bfcl": {
                         # error entries can be strings or dicts (detailed sub-error objects)
                         "value": "\n".join(
                             e if isinstance(e, str) else json.dumps(e) for e in errors
-                        ) if errors else "none"
+                        )
+                        if errors
+                        else "none"
                     }
                 },
-                "bfcl_latency_total_s": {
-                    "bfcl": {"value": latency}
-                },
-                "bfcl_input_tokens_total": {
-                    "bfcl": {"value": input_tokens}
-                },
-                "bfcl_output_tokens_total": {
-                    "bfcl": {"value": output_tokens}
-                },
+                "bfcl_latency_total_s": {"bfcl": {"value": latency}},
+                "bfcl_input_tokens_total": {"bfcl": {"value": input_tokens}},
+                "bfcl_output_tokens_total": {"bfcl": {"value": output_tokens}},
+            }
+
+            # InspectorRAGet labels are per-(task, model) nominal descriptors that
+            # characterise output without scoring it. Unlike metrics, labels have no natural
+            # ordering or aggregation semantics; InspectorRAGet surfaces them in the Model
+            # Characteristics tab for distribution analysis across models.
+            #
+            # "Error Type" stores the BFCL error_type string rather than a metric because
+            # it is a categorical classifier (e.g., "type_error:nested",
+            # "wrong_func_name"), not a quantity. Treating it as a metric would imply
+            # ordinal meaning that doesn't exist. As a label it appears in grouped bar
+            # charts showing how error types are distributed per model, which is the
+            # analysis researchers actually want.
+            labels: dict = {
+                "Error Type": error_type if error_type is not None else "N/A"
             }
 
             result_entry: dict = {
@@ -902,6 +1046,7 @@ def convert_tool_calling(
                 "model_id": model_id,
                 "output": output,
                 "scores": scores,
+                "labels": labels,
             }
 
             results_list.append(result_entry)
@@ -918,7 +1063,11 @@ def convert_tool_calling(
             "order": "ascending",
             "values": [
                 {"value": "correct", "numeric_value": 1, "display_value": "Correct"},
-                {"value": "incorrect", "numeric_value": 0, "display_value": "Incorrect"},
+                {
+                    "value": "incorrect",
+                    "numeric_value": 0,
+                    "display_value": "Incorrect",
+                },
             ],
         },
         {
@@ -936,20 +1085,29 @@ def convert_tool_calling(
             "aggregator": "majority",
             "order": "descending",
             "values": [
-                {"value": "correct",          "numeric_value": 0.0,  "display_value": "Correct"},
-                {"value": "wrong_arguments",  "numeric_value": 0.25, "display_value": "Wrong Arguments"},
-                {"value": "wrong_function",   "numeric_value": 0.5,  "display_value": "Wrong Function"},
-                {"value": "unknown",          "numeric_value": 0.5,  "display_value": "Unknown"},
-                {"value": "irrelevance_error","numeric_value": 0.75, "display_value": "Irrelevance Error"},
-                {"value": "malformed_output", "numeric_value": 1.0,  "display_value": "Malformed Output"},
+                {"value": "correct", "numeric_value": 0.0, "display_value": "Correct"},
+                {
+                    "value": "wrong_arguments",
+                    "numeric_value": 0.25,
+                    "display_value": "Wrong Arguments",
+                },
+                {
+                    "value": "wrong_function",
+                    "numeric_value": 0.5,
+                    "display_value": "Wrong Function",
+                },
+                {"value": "unknown", "numeric_value": 0.5, "display_value": "Unknown"},
+                {
+                    "value": "irrelevance_error",
+                    "numeric_value": 0.75,
+                    "display_value": "Irrelevance Error",
+                },
+                {
+                    "value": "malformed_output",
+                    "numeric_value": 1.0,
+                    "display_value": "Malformed Output",
+                },
             ],
-        },
-        {
-            "name": "bfcl_error_type",
-            "display_name": "Error Type",
-            "description": "Raw BFCL error type string (e.g. type_error:nested). Empty for correct tasks.",
-            "author": "algorithm",
-            "type": "text",
         },
         {
             "name": "bfcl_errors",
@@ -999,11 +1157,13 @@ def convert_tool_calling(
     ]
 
     # Collect unique bfcl_category values for the filters block.
-    bfcl_categories = sorted({
-        task.get("bfcl_category", "")
-        for task in tasks_list
-        if task.get("bfcl_category")
-    })
+    bfcl_categories = sorted(
+        {
+            task.get("bfcl_category", "")
+            for task in tasks_list
+            if task.get("bfcl_category")
+        }
+    )
 
     # --- Build models block ---
     models = [
@@ -1028,6 +1188,7 @@ def convert_tool_calling(
 # ---------------------------------------------------------------------------
 # Agentic conversion helpers
 # ---------------------------------------------------------------------------
+
 
 def _to_snake(name: str) -> str:
     """Convert a CamelCase or PascalCase class name to snake_case.
@@ -1079,7 +1240,9 @@ def load_func_doc_dir(dataset_dir: Path) -> dict[str, list[dict]]:
     return class_tools
 
 
-def load_agentic_dataset_dir(dataset_dir: Path, categories: set[str]) -> dict[str, dict]:
+def load_agentic_dataset_dir(
+    dataset_dir: Path, categories: set[str]
+) -> dict[str, dict]:
     """
     Load multi-turn BFCL dataset files (e.g. BFCL_v3_multi_turn_base.json).
     Returns task_id → record. Records include question, initial_config, path, involved_classes.
@@ -1256,20 +1419,26 @@ def inference_log_to_messages(inference_log: list) -> list[dict]:
 
                 elif role == "tool":
                     content = entry.get("content", "")
-                    tool_msgs.append({
-                        "role": "tool",
-                        "tool_call_id": entry.get("tool_call_id", ""),
-                        "content": content if isinstance(content, str) else json.dumps(content),
-                    })
+                    tool_msgs.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": entry.get("tool_call_id", ""),
+                            "content": content
+                            if isinstance(content, str)
+                            else json.dumps(content),
+                        }
+                    )
 
-            step_results.append({
-                "asst_content": asst_content,
-                "tool_calls": tool_calls,
-                "tool_msgs": tool_msgs,
-                "decode_error": decode_error,
-                "empty_response": empty_response,
-                "force_quit": force_quit,
-            })
+            step_results.append(
+                {
+                    "asst_content": asst_content,
+                    "tool_calls": tool_calls,
+                    "tool_msgs": tool_msgs,
+                    "decode_error": decode_error,
+                    "empty_response": empty_response,
+                    "force_quit": force_quit,
+                }
+            )
 
         if not step_results:
             continue
@@ -1300,7 +1469,13 @@ def inference_log_to_messages(inference_log: list) -> list[dict]:
             else:
                 invocation_output["content"] = sr["asst_content"]
             # Label matches the step_N key in the BFCL inference log for cross-referencing.
-            trace_events.append({"type": "invocation", "label": f"step_{step_idx}", "output": invocation_output})
+            trace_events.append(
+                {
+                    "type": "invocation",
+                    "label": f"step_{step_idx}",
+                    "output": invocation_output,
+                }
+            )
 
             # Tool executions follow each intermediate invocation that produced tool calls.
             for tool_msg in sr["tool_msgs"]:
@@ -1365,7 +1540,9 @@ def _parse_tool_calls_from_raw(raw_outputs: list) -> list[dict] | None:
         # Try splitting on top-level commas to handle parallel calls
         for call_str in _split_parallel_calls(raw_clean):
             call_str = call_str.strip()
-            m = re.match(r"^([A-Za-z_][A-Za-z0-9_.]*)\s*\((.*)\)\s*$", call_str, re.DOTALL)
+            m = re.match(
+                r"^([A-Za-z_][A-Za-z0-9_.]*)\s*\((.*)\)\s*$", call_str, re.DOTALL
+            )
             if not m:
                 return None  # Not a parseable call — bail out entirely
             func_name = m.group(1)
@@ -1373,7 +1550,9 @@ def _parse_tool_calls_from_raw(raw_outputs: list) -> list[dict] | None:
             args = _parse_kwargs(args_str)
             if args is None:
                 return None
-            calls.append({"id": str(uuid.uuid4()), "name": func_name, "arguments": args})
+            calls.append(
+                {"id": str(uuid.uuid4()), "name": func_name, "arguments": args}
+            )
 
     return calls if calls else None
 
@@ -1388,19 +1567,19 @@ def _split_parallel_calls(s: str) -> list[str]:
     depth = 0
     current: list[str] = []
     for ch in s:
-        if ch == '(':
+        if ch == "(":
             depth += 1
             current.append(ch)
-        elif ch == ')':
+        elif ch == ")":
             depth -= 1
             current.append(ch)
-        elif ch == ',' and depth == 0:
-            parts.append(''.join(current).strip())
+        elif ch == "," and depth == 0:
+            parts.append("".join(current).strip())
             current = []
         else:
             current.append(ch)
     if current:
-        parts.append(''.join(current).strip())
+        parts.append("".join(current).strip())
     return [p for p in parts if p]
 
 
@@ -1419,18 +1598,18 @@ def _parse_kwargs(args_str: str) -> dict | None:
     remaining = args_str.strip()
     while remaining:
         # Match key=
-        key_match = re.match(r'^([A-Za-z_][A-Za-z0-9_]*)\s*=\s*', remaining)
+        key_match = re.match(r"^([A-Za-z_][A-Za-z0-9_]*)\s*=\s*", remaining)
         if not key_match:
             return None
         key = key_match.group(1)
-        remaining = remaining[key_match.end():]
+        remaining = remaining[key_match.end() :]
 
         # Find the end of the value by scanning brackets/quotes
         value_end = _find_value_end(remaining)
         if value_end < 0:
             return None
         value_str = remaining[:value_end].strip()
-        remaining = remaining[value_end:].lstrip(', ')
+        remaining = remaining[value_end:].lstrip(", ")
 
         try:
             result[key] = ast.literal_eval(value_str)
@@ -1452,24 +1631,26 @@ def _find_value_end(s: str) -> int:
     while i < len(s):
         ch = s[i]
         if in_str:
-            if ch == '\\':
+            if ch == "\\":
                 i += 2
                 continue
             if ch == in_str:
                 in_str = None
         elif ch in ('"', "'"):
             in_str = ch
-        elif ch in ('(', '[', '{'):
+        elif ch in ("(", "[", "{"):
             depth += 1
-        elif ch in (')', ']', '}'):
+        elif ch in (")", "]", "}"):
             depth -= 1
-        elif ch == ',' and depth == 0:
+        elif ch == "," and depth == 0:
             return i
         i += 1
     return i  # end of string
 
 
-def ground_truth_turns_to_target(path: list, ground_truth_turns: list | None) -> list[dict]:
+def ground_truth_turns_to_target(
+    path: list, ground_truth_turns: list | None
+) -> list[dict]:
     """
     Build a TaskTarget[] for an agentic task.
 
@@ -1500,7 +1681,10 @@ def ground_truth_turns_to_target(path: list, ground_truth_turns: list | None) ->
 # Core conversion: agentic task type
 # ---------------------------------------------------------------------------
 
-def convert_agentic(bfcl_root: Path, dataset_dir: Path | None, output_name: str) -> dict:
+
+def convert_agentic(
+    bfcl_root: Path, dataset_dir: Path | None, output_name: str
+) -> dict:
     """
     Walk bfcl_root, collect all multi-turn BFCL categories, and produce an
     InspectorRAGet JSON document with task_type "agentic".
@@ -1523,7 +1707,9 @@ def convert_agentic(bfcl_root: Path, dataset_dir: Path | None, output_name: str)
     if not model_dirs:
         sys.exit(f"Error: no model output directories found under {bfcl_root}")
 
-    print(f"Found {len(model_dirs)} model director{'y' if len(model_dirs) == 1 else 'ies'} under {bfcl_root}")
+    print(
+        f"Found {len(model_dirs)} model director{'y' if len(model_dirs) == 1 else 'ies'} under {bfcl_root}"
+    )
 
     for model_dir in model_dirs:
         print(f"\nProcessing: {model_dir.name}")
@@ -1556,7 +1742,9 @@ def convert_agentic(bfcl_root: Path, dataset_dir: Path | None, output_name: str)
                     task_id = record.get("id")
                     if task_id:
                         score_map[model_id][task_id] = record
-                print(f"  Loaded {len(failure_records)} failure records from {score_file.name}")
+                print(
+                    f"  Loaded {len(failure_records)} failure records from {score_file.name}"
+                )
 
     if not result_map:
         print(
@@ -1573,7 +1761,9 @@ def convert_agentic(bfcl_root: Path, dataset_dir: Path | None, output_name: str)
         dataset_records = load_agentic_dataset_dir(dataset_dir, AGENTIC_CATEGORIES)
         class_tools = load_func_doc_dir(dataset_dir)
         print(f"\nLoaded {len(dataset_records)} task definitions from dataset dir")
-        print(f"Loaded {len(class_tools)} toolkit class definitions from multi_turn_func_doc/")
+        print(
+            f"Loaded {len(class_tools)} toolkit class definitions from multi_turn_func_doc/"
+        )
     else:
         print("\nNo --dataset-dir provided. Tasks will have no initial state or tools.")
 
@@ -1588,7 +1778,9 @@ def convert_agentic(bfcl_root: Path, dataset_dir: Path | None, output_name: str)
         task_ids_to_emit = all_result_ids
 
     token_avgs = model_token_averages(result_map)
-    print(f"\nBuilding output for {len(task_ids_to_emit)} tasks across {len(all_model_ids)} model(s)...")
+    print(
+        f"\nBuilding output for {len(task_ids_to_emit)} tasks across {len(all_model_ids)} model(s)..."
+    )
 
     tasks_list: list[dict] = []
     results_list: list[dict] = []
@@ -1634,7 +1826,9 @@ def convert_agentic(bfcl_root: Path, dataset_dir: Path | None, output_name: str)
         if initial_config:
             # Store as a single context entry so the agentic TaskView renders it
             # under "Initial State" using the contexts field.
-            task["contexts"] = [{"text": json.dumps(initial_config, ensure_ascii=False)}]
+            task["contexts"] = [
+                {"text": json.dumps(initial_config, ensure_ascii=False)}
+            ]
         if task_tools:
             task["tools"] = task_tools
         if targets:
@@ -1662,43 +1856,67 @@ def convert_agentic(bfcl_root: Path, dataset_dir: Path | None, output_name: str)
                 error_type = error_dict.get("error_type")
                 raw_msg = error_dict.get("error_message", "")
                 # BFCL sometimes stores error_message as a list of strings
-                error_message = "\n".join(raw_msg) if isinstance(raw_msg, list) else raw_msg
+                error_message = (
+                    "\n".join(raw_msg) if isinstance(raw_msg, list) else raw_msg
+                )
             else:
                 # Defensive: some score records may use the single-turn flat format
                 error_type = score_record.get("error_type") if score_record else None
-                error_message = "; ".join(str(e) for e in error_dict) if isinstance(error_dict, list) else str(error_dict)
+                error_message = (
+                    "; ".join(str(e) for e in error_dict)
+                    if isinstance(error_dict, list)
+                    else str(error_dict)
+                )
 
             # For per-task targets: use possible_answer from the score record when
             # available (failing tasks only). This is the per-turn ground truth as
             # list[list[str]]. Prefer it over the dataset's path-only ground truth.
-            score_possible_answer = score_record.get("possible_answer") if score_record else None
+            score_possible_answer = (
+                score_record.get("possible_answer") if score_record else None
+            )
             if score_possible_answer and not task.get("targets"):
-                task["targets"] = ground_truth_turns_to_target(path, score_possible_answer)
+                task["targets"] = ground_truth_turns_to_target(
+                    path, score_possible_answer
+                )
 
             # Prefer score record's inference_log for failing tasks — it is the same
             # log that was used for evaluation and is always present for failures.
             # Fall back to result record for passing tasks.
-            log_source = score_record if (score_record and score_record.get("inference_log")) else result_record
+            log_source = (
+                score_record
+                if (score_record and score_record.get("inference_log"))
+                else result_record
+            )
             inference_log = (log_source or {}).get("inference_log", [])
             output_messages = inference_log_to_messages(inference_log)
 
             # Fallback: if no thread could be reconstructed, build a minimal one
             # from the goal + error so the instance view is not empty.
             if not output_messages and goal_message:
-                output_messages = [{"role": "user", "content": goal_message.get("content", "")}]
+                output_messages = [
+                    {"role": "user", "content": goal_message.get("content", "")}
+                ]
                 if is_failing and error_message:
-                    output_messages.append({
-                        "role": "assistant",
-                        "content": f"[Run failed: {error_type or 'unknown'}]\n{error_message}",
-                    })
+                    output_messages.append(
+                        {
+                            "role": "assistant",
+                            "content": f"[Run failed: {error_type or 'unknown'}]\n{error_message}",
+                        }
+                    )
 
-            severity_value, severity_numeric, severity_display = derive_severity(is_valid, error_type)
+            severity_value, severity_numeric, severity_display = derive_severity(
+                is_valid, error_type
+            )
 
             rec = result_record or {}
             latency = token_sum(rec.get("latency")) or 600.0
             avg = token_avgs.get(model_id, {})
-            input_tokens = token_sum(rec.get("input_token_count")) or avg.get("input", 0.0)
-            output_tokens = token_sum(rec.get("output_token_count")) or avg.get("output", 0.0)
+            input_tokens = token_sum(rec.get("input_token_count")) or avg.get(
+                "input", 0.0
+            )
+            output_tokens = token_sum(rec.get("output_token_count")) or avg.get(
+                "output", 0.0
+            )
 
             # Stamp metadata.status on each assistant and tool message so the UI
             # can show a visual pass/fail/warn indicator per message.
@@ -1707,7 +1925,11 @@ def convert_agentic(bfcl_root: Path, dataset_dir: Path | None, output_name: str)
             # their turns and are stamped normally (pass/warn).
             is_force_terminated = error_type == "multi_turn:force_terminated"
             last_asst_idx = max(
-                (i for i, m in enumerate(output_messages) if m.get("role") == "assistant"),
+                (
+                    i
+                    for i, m in enumerate(output_messages)
+                    if m.get("role") == "assistant"
+                ),
                 default=None,
             )
             for i, msg in enumerate(output_messages):
@@ -1722,7 +1944,10 @@ def convert_agentic(bfcl_root: Path, dataset_dir: Path | None, output_name: str)
                 else:
                     status, status_def = message_status_and_definition(msg)
                     if status:
-                        msg["metadata"] = {"status": status, "statusDefinition": status_def}
+                        msg["metadata"] = {
+                            "status": status,
+                            "statusDefinition": status_def,
+                        }
 
             scores: dict = {
                 "bfcl_correctness": {
@@ -1738,21 +1963,30 @@ def convert_agentic(bfcl_root: Path, dataset_dir: Path | None, output_name: str)
                         "display_value": severity_display,
                     }
                 },
-                "bfcl_error_type": {
-                    "bfcl": {"value": error_type if error_type is not None else "none"}
-                },
                 "bfcl_errors": {
                     "bfcl": {"value": error_message if error_message else "none"}
                 },
-                "bfcl_latency_total_s": {
-                    "bfcl": {"value": latency}
-                },
-                "bfcl_input_tokens_total": {
-                    "bfcl": {"value": input_tokens}
-                },
-                "bfcl_output_tokens_total": {
-                    "bfcl": {"value": output_tokens}
-                },
+                "bfcl_latency_total_s": {"bfcl": {"value": latency}},
+                "bfcl_input_tokens_total": {"bfcl": {"value": input_tokens}},
+                "bfcl_output_tokens_total": {"bfcl": {"value": output_tokens}},
+            }
+
+            # InspectorRAGet labels are per-(task, model) nominal descriptors that
+            # characterise output without scoring it. Unlike metrics, labels have no natural
+            # ordering or aggregation semantics; InspectorRAGet surfaces them in the Model
+            # Characteristics tab for distribution analysis across models.
+            #
+            # "Error Type" stores the BFCL error_type string rather than a metric because
+            # it is a categorical classifier (e.g., "multi_turn:instance_state_mismatch",
+            # "multi_turn:force_terminated"), not a quantity. Treating it as a metric would
+            # imply ordinal meaning that doesn't exist. As a label it appears in grouped bar
+            # charts showing how error types are distributed per model, which is the
+            # analysis researchers actually want. The "multi_turn:" prefix is stripped to
+            # keep label values concise; the agentic context is already implied by the tab.
+            labels: dict = {
+                "Error Type": error_type.removeprefix("multi_turn:")
+                if error_type is not None
+                else "N/A"
             }
 
             result_entry: dict = {
@@ -1760,6 +1994,7 @@ def convert_agentic(bfcl_root: Path, dataset_dir: Path | None, output_name: str)
                 "model_id": model_id,
                 "output": output_messages,
                 "scores": scores,
+                "labels": labels,
             }
 
             # Structured error diagnostics from BFCL score record details.
@@ -1771,7 +2006,7 @@ def convert_agentic(bfcl_root: Path, dataset_dir: Path | None, output_name: str)
 
             results_list.append(result_entry)
 
-    # Metrics: same set as tool_calling (correctness, severity, error type, errors, latency)
+    # Metrics: same set as tool_calling (correctness, severity, errors, latency)
     # plus bfcl_turn_count for multi-turn depth analysis.
     metrics = [
         {
@@ -1783,8 +2018,12 @@ def convert_agentic(bfcl_root: Path, dataset_dir: Path | None, output_name: str)
             "aggregator": "majority",
             "order": "ascending",
             "values": [
-                {"value": "correct",   "numeric_value": 1, "display_value": "Correct"},
-                {"value": "incorrect", "numeric_value": 0, "display_value": "Incorrect"},
+                {"value": "correct", "numeric_value": 1, "display_value": "Correct"},
+                {
+                    "value": "incorrect",
+                    "numeric_value": 0,
+                    "display_value": "Incorrect",
+                },
             ],
         },
         {
@@ -1802,20 +2041,29 @@ def convert_agentic(bfcl_root: Path, dataset_dir: Path | None, output_name: str)
             "aggregator": "majority",
             "order": "descending",
             "values": [
-                {"value": "correct",          "numeric_value": 0.0,  "display_value": "Correct"},
-                {"value": "wrong_arguments",  "numeric_value": 0.25, "display_value": "Wrong Arguments"},
-                {"value": "wrong_function",   "numeric_value": 0.5,  "display_value": "Wrong Function"},
-                {"value": "unknown",          "numeric_value": 0.5,  "display_value": "Unknown"},
-                {"value": "irrelevance_error","numeric_value": 0.75, "display_value": "Irrelevance Error"},
-                {"value": "malformed_output", "numeric_value": 1.0,  "display_value": "Malformed Output"},
+                {"value": "correct", "numeric_value": 0.0, "display_value": "Correct"},
+                {
+                    "value": "wrong_arguments",
+                    "numeric_value": 0.25,
+                    "display_value": "Wrong Arguments",
+                },
+                {
+                    "value": "wrong_function",
+                    "numeric_value": 0.5,
+                    "display_value": "Wrong Function",
+                },
+                {"value": "unknown", "numeric_value": 0.5, "display_value": "Unknown"},
+                {
+                    "value": "irrelevance_error",
+                    "numeric_value": 0.75,
+                    "display_value": "Irrelevance Error",
+                },
+                {
+                    "value": "malformed_output",
+                    "numeric_value": 1.0,
+                    "display_value": "Malformed Output",
+                },
             ],
-        },
-        {
-            "name": "bfcl_error_type",
-            "display_name": "Error Type",
-            "description": "Raw BFCL error type string. 'none' for correct tasks.",
-            "author": "algorithm",
-            "type": "text",
         },
         {
             "name": "bfcl_errors",
@@ -1866,9 +2114,13 @@ def convert_agentic(bfcl_root: Path, dataset_dir: Path | None, output_name: str)
         },
     ]
 
-    bfcl_categories = sorted({
-        task.get("bfcl_category", "") for task in tasks_list if task.get("bfcl_category")
-    })
+    bfcl_categories = sorted(
+        {
+            task.get("bfcl_category", "")
+            for task in tasks_list
+            if task.get("bfcl_category")
+        }
+    )
 
     models = [
         {"model_id": mid, "name": model_dir_names.get(mid, mid), "owner": ""}
@@ -1892,6 +2144,7 @@ def convert_agentic(bfcl_root: Path, dataset_dir: Path | None, output_name: str)
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(
@@ -1967,7 +2220,9 @@ Examples:
     if args.dataset_dir and not args.dataset_dir.exists():
         sys.exit(f"Error: --dataset-dir path does not exist: {args.dataset_dir}")
 
-    output = args.output if args.output else args.bfcl_root / f"bfcl_{args.task_type}.json"
+    output = (
+        args.output if args.output else args.bfcl_root / f"bfcl_{args.task_type}.json"
+    )
 
     if args.task_type == "tool_calling":
         result = convert_tool_calling(args.bfcl_root, args.dataset_dir, args.name)

--- a/converters/bfcl/download_dataset.sh
+++ b/converters/bfcl/download_dataset.sh
@@ -75,6 +75,11 @@ if [[ "$VERSION" == "v3" ]]; then
     "possible_answer/BFCL_v3_live_multiple.json"
     "possible_answer/BFCL_v3_live_parallel.json"
     "possible_answer/BFCL_v3_live_parallel_multiple.json"
+    # Multi-turn ground-truth answers (agentic task type)
+    "possible_answer/BFCL_v3_multi_turn_base.json"
+    "possible_answer/BFCL_v3_multi_turn_miss_func.json"
+    "possible_answer/BFCL_v3_multi_turn_miss_param.json"
+    "possible_answer/BFCL_v3_multi_turn_long_context.json"
   )
   # Tool definitions for multi-turn (agentic) tasks.
   # Each file defines the tools available in one virtual environment class.
@@ -125,6 +130,14 @@ else
     "possible_answer/BFCL_v4_live_multiple.json"
     "possible_answer/BFCL_v4_live_parallel.json"
     "possible_answer/BFCL_v4_live_parallel_multiple.json"
+    # Multi-turn ground-truth answers (agentic task type)
+    "possible_answer/BFCL_v4_multi_turn_base.json"
+    "possible_answer/BFCL_v4_multi_turn_miss_func.json"
+    "possible_answer/BFCL_v4_multi_turn_miss_param.json"
+    "possible_answer/BFCL_v4_multi_turn_long_context.json"
+    # V4 agentic category answers
+    "possible_answer/BFCL_v4_memory.json"
+    "possible_answer/BFCL_v4_web_search.json"
   )
   # Tool definitions for multi-turn (agentic) tasks.
   # Each file defines the tools available in one virtual environment class.

--- a/src/__tests__/expressions.test.ts
+++ b/src/__tests__/expressions.test.ts
@@ -1,0 +1,521 @@
+/**
+ *
+ * Copyright 2023-present InspectorRAGet Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **/
+
+import { describe, it, expect } from 'vitest';
+import {
+  validate,
+  evaluate,
+  validateLabelExpression,
+  evaluateLabels,
+  EXPRESSION_OPERATORS,
+} from '@/src/utilities/expressions';
+import { Metric, ModelResult } from '@/src/types';
+
+// --- Fixtures ---
+
+const numericalMetric: Metric = {
+  name: 'score',
+  author: 'algorithm',
+  type: 'numerical',
+  range: [0, 1],
+  aggregator: 'mean',
+};
+
+const categoricalMetric: Metric = {
+  name: 'quality',
+  author: 'human',
+  type: 'categorical',
+  aggregator: 'majority',
+  values: [
+    { value: 'bad', numericValue: 0 },
+    { value: 'ok', numericValue: 1 },
+    { value: 'good', numericValue: 2 },
+    { value: 'excellent', numericValue: 3 },
+  ],
+};
+
+function makeResult(
+  taskId: string,
+  modelId: string,
+  aggValue: string | number,
+  metric: Metric = numericalMetric,
+): ModelResult {
+  return {
+    taskId,
+    modelId,
+    output: [],
+    scores: {
+      [metric.name]: { system: { value: aggValue } },
+    },
+    [`${metric.name}_agg`]: { value: aggValue, level: 'high' },
+  } as any;
+}
+
+function makeResultsPerTaskPerModel(results: ModelResult[]): {
+  [taskId: string]: { [modelId: string]: ModelResult };
+} {
+  const map: { [taskId: string]: { [modelId: string]: ModelResult } } = {};
+  for (const r of results) {
+    if (!map[r.taskId]) map[r.taskId] = {};
+    map[r.taskId][r.modelId] = r;
+  }
+  return map;
+}
+
+const modelIds = ['m1', 'm2'];
+
+// --- validate ---
+
+describe('validate', () => {
+  it('rejects an empty expression at root', () => {
+    expect(validate({})).not.toBeNull();
+  });
+
+  it('accepts a valid $eq expression', () => {
+    expect(validate({ m1: { $eq: 0.9 } }, modelIds)).toBeNull();
+  });
+
+  it('accepts a valid $neq expression', () => {
+    expect(validate({ m1: { $neq: 0.5 } }, modelIds)).toBeNull();
+  });
+
+  it('accepts a valid $and expression', () => {
+    expect(
+      validate(
+        { $and: [{ m1: { $gt: 0.8 } }, { m2: { $lt: 0.5 } }] },
+        modelIds,
+      ),
+    ).toBeNull();
+  });
+
+  it('accepts a valid $or expression', () => {
+    expect(
+      validate({ $or: [{ m1: { $eq: 0.9 } }, { m2: { $eq: 0.8 } }] }, modelIds),
+    ).toBeNull();
+  });
+
+  it('rejects unknown model ID', () => {
+    expect(validate({ unknown: { $eq: 0.9 } }, modelIds)).not.toBeNull();
+  });
+
+  it('rejects $and with empty array', () => {
+    expect(validate({ $and: [] }, modelIds)).not.toBeNull();
+  });
+
+  it('rejects logical operator directly under model ID', () => {
+    expect(validate({ m1: { $and: [] } }, modelIds)).not.toBeNull();
+  });
+
+  // --- $in ---
+
+  it('accepts a valid $in expression', () => {
+    expect(
+      validate({ m1: { $in: ['good', 'excellent'] } }, modelIds),
+    ).toBeNull();
+  });
+
+  it('accepts a valid $nin expression', () => {
+    expect(validate({ m1: { $nin: ['bad'] } }, modelIds)).toBeNull();
+  });
+
+  it('accepts $in with numeric values', () => {
+    expect(validate({ m1: { $in: [0.8, 0.9] } }, modelIds)).toBeNull();
+  });
+
+  it('rejects $in with empty array', () => {
+    expect(validate({ m1: { $in: [] } }, modelIds)).not.toBeNull();
+  });
+
+  it('rejects $nin with empty array', () => {
+    expect(validate({ m1: { $nin: [] } }, modelIds)).not.toBeNull();
+  });
+
+  it('rejects $in with non-primitive array elements', () => {
+    expect(
+      validate({ m1: { $in: [{ nested: true }] } }, modelIds),
+    ).not.toBeNull();
+  });
+
+  it('rejects $in without a preceding model ID', () => {
+    expect(validate({ $in: ['good'] }, modelIds)).not.toBeNull();
+  });
+
+  it('rejects $nin with a non-array value', () => {
+    expect(validate({ m1: { $nin: 'bad' } }, modelIds)).not.toBeNull();
+  });
+});
+
+// --- evaluate: existing operators ---
+
+describe('evaluate — existing operators', () => {
+  it('matches tasks where model value satisfies $eq', () => {
+    const results = [
+      makeResult('t1', 'm1', 0.9),
+      makeResult('t1', 'm2', 0.7),
+      makeResult('t2', 'm1', 0.5),
+      makeResult('t2', 'm2', 0.5),
+    ];
+    const map = makeResultsPerTaskPerModel(results);
+    const matched = evaluate(map, { m1: { $eq: 0.9 } }, numericalMetric);
+    const taskIds = matched.map((r) => r.taskId);
+    expect(taskIds).toContain('t1');
+    expect(taskIds).not.toContain('t2');
+  });
+
+  it('$and returns intersection of matched tasks', () => {
+    const results = [
+      makeResult('t1', 'm1', 0.9),
+      makeResult('t1', 'm2', 0.8),
+      makeResult('t2', 'm1', 0.9),
+      makeResult('t2', 'm2', 0.3),
+    ];
+    const map = makeResultsPerTaskPerModel(results);
+    const matched = evaluate(
+      map,
+      { $and: [{ m1: { $eq: 0.9 } }, { m2: { $gt: 0.7 } }] },
+      numericalMetric,
+    );
+    const taskIds = new Set(matched.map((r) => r.taskId));
+    // t1 satisfies both; t2 fails m2 condition
+    expect(taskIds.has('t1')).toBe(true);
+    expect(taskIds.has('t2')).toBe(false);
+  });
+
+  it('$or returns union of matched tasks', () => {
+    const results = [
+      makeResult('t1', 'm1', 0.9),
+      makeResult('t1', 'm2', 0.3),
+      makeResult('t2', 'm1', 0.3),
+      makeResult('t2', 'm2', 0.8),
+    ];
+    const map = makeResultsPerTaskPerModel(results);
+    const matched = evaluate(
+      map,
+      { $or: [{ m1: { $gt: 0.8 } }, { m2: { $gt: 0.7 } }] },
+      numericalMetric,
+    );
+    const taskIds = new Set(matched.map((r) => r.taskId));
+    expect(taskIds.has('t1')).toBe(true);
+    expect(taskIds.has('t2')).toBe(true);
+  });
+});
+
+// --- evaluate: $in / $nin ---
+
+describe('evaluate — $in and $nin', () => {
+  it('$in matches tasks where model value is in the set', () => {
+    const results = [
+      makeResult('t1', 'm1', 2, categoricalMetric), // 'good'
+      makeResult('t1', 'm2', 1, categoricalMetric), // 'ok'
+      makeResult('t2', 'm1', 0, categoricalMetric), // 'bad'
+      makeResult('t2', 'm2', 3, categoricalMetric), // 'excellent'
+    ];
+    const map = makeResultsPerTaskPerModel(results);
+    // $in: ['good', 'excellent'] — numeric 2 and 3
+    const matched = evaluate(
+      map,
+      { m1: { $in: ['good', 'excellent'] } },
+      categoricalMetric,
+    );
+    const taskIds = new Set(matched.map((r) => r.taskId));
+    expect(taskIds.has('t1')).toBe(true); // m1 = 'good' (2)
+    expect(taskIds.has('t2')).toBe(false); // m1 = 'bad' (0)
+  });
+
+  it('$nin excludes tasks where model value is in the set', () => {
+    const results = [
+      makeResult('t1', 'm1', 0, categoricalMetric), // 'bad'
+      makeResult('t1', 'm2', 2, categoricalMetric),
+      makeResult('t2', 'm1', 2, categoricalMetric), // 'good'
+      makeResult('t2', 'm2', 2, categoricalMetric),
+    ];
+    const map = makeResultsPerTaskPerModel(results);
+    const matched = evaluate(map, { m1: { $nin: ['bad'] } }, categoricalMetric);
+    const taskIds = new Set(matched.map((r) => r.taskId));
+    expect(taskIds.has('t1')).toBe(false); // m1 = 'bad' excluded
+    expect(taskIds.has('t2')).toBe(true); // m1 = 'good' passes
+  });
+
+  it('$in works with numeric values directly', () => {
+    const results = [
+      makeResult('t1', 'm1', 0.8),
+      makeResult('t1', 'm2', 0.5),
+      makeResult('t2', 'm1', 0.5),
+      makeResult('t2', 'm2', 0.5),
+    ];
+    const map = makeResultsPerTaskPerModel(results);
+    const matched = evaluate(map, { m1: { $in: [0.8, 0.9] } }, numericalMetric);
+    const taskIds = new Set(matched.map((r) => r.taskId));
+    expect(taskIds.has('t1')).toBe(true);
+    expect(taskIds.has('t2')).toBe(false);
+  });
+
+  it('$in with a single-value array', () => {
+    const results = [makeResult('t1', 'm1', 0.8), makeResult('t1', 'm2', 0.5)];
+    const map = makeResultsPerTaskPerModel(results);
+    const matched = evaluate(map, { m1: { $in: [0.8] } }, numericalMetric);
+    expect(matched.map((r) => r.taskId)).toContain('t1');
+  });
+
+  it('$in combined with $and', () => {
+    const results = [
+      makeResult('t1', 'm1', 2, categoricalMetric), // 'good'
+      makeResult('t1', 'm2', 3, categoricalMetric), // 'excellent'
+      makeResult('t2', 'm1', 2, categoricalMetric), // 'good'
+      makeResult('t2', 'm2', 0, categoricalMetric), // 'bad'
+    ];
+    const map = makeResultsPerTaskPerModel(results);
+    const matched = evaluate(
+      map,
+      {
+        $and: [
+          { m1: { $in: ['good', 'excellent'] } },
+          { m2: { $nin: ['bad'] } },
+        ],
+      },
+      categoricalMetric,
+    );
+    const taskIds = new Set(matched.map((r) => r.taskId));
+    // t1: m1=good (pass), m2=excellent (not bad, pass) => match
+    // t2: m1=good (pass), m2=bad (fail $nin) => no match
+    expect(taskIds.has('t1')).toBe(true);
+    expect(taskIds.has('t2')).toBe(false);
+  });
+});
+
+// --- validateLabelExpression ---
+
+describe('validateLabelExpression', () => {
+  it('accepts $eq', () => {
+    expect(
+      validateLabelExpression({ m1: { $eq: 'force_terminated' } }, ['m1']),
+    ).toBeNull();
+  });
+
+  it('accepts $neq', () => {
+    expect(validateLabelExpression({ m1: { $neq: 'N/A' } }, ['m1'])).toBeNull();
+  });
+
+  it('accepts $in', () => {
+    expect(
+      validateLabelExpression({ m1: { $in: ['force_terminated', 'N/A'] } }, [
+        'm1',
+      ]),
+    ).toBeNull();
+  });
+
+  it('accepts $nin', () => {
+    expect(
+      validateLabelExpression({ m1: { $nin: ['N/A'] } }, ['m1']),
+    ).toBeNull();
+  });
+
+  it('accepts $and', () => {
+    expect(
+      validateLabelExpression(
+        { $and: [{ m1: { $eq: 'foo' } }, { m2: { $neq: 'bar' } }] },
+        ['m1', 'm2'],
+      ),
+    ).toBeNull();
+  });
+
+  it('accepts $or', () => {
+    expect(
+      validateLabelExpression(
+        { $or: [{ m1: { $eq: 'foo' } }, { m1: { $eq: 'bar' } }] },
+        ['m1'],
+      ),
+    ).toBeNull();
+  });
+
+  it('rejects $gt', () => {
+    expect(
+      validateLabelExpression({ m1: { $gt: 0.8 } }, ['m1']),
+    ).not.toBeNull();
+  });
+
+  it('rejects $gte', () => {
+    expect(
+      validateLabelExpression({ m1: { $gte: 0.8 } }, ['m1']),
+    ).not.toBeNull();
+  });
+
+  it('rejects $lt', () => {
+    expect(
+      validateLabelExpression({ m1: { $lt: 0.5 } }, ['m1']),
+    ).not.toBeNull();
+  });
+
+  it('rejects $lte', () => {
+    expect(
+      validateLabelExpression({ m1: { $lte: 0.5 } }, ['m1']),
+    ).not.toBeNull();
+  });
+
+  it('rejects empty expression at root', () => {
+    expect(validateLabelExpression({})).not.toBeNull();
+  });
+
+  it('rejects unknown model ID', () => {
+    expect(
+      validateLabelExpression({ unknown: { $eq: 'x' } }, ['m1']),
+    ).not.toBeNull();
+  });
+
+  it('rejects $in with empty array', () => {
+    expect(validateLabelExpression({ m1: { $in: [] } }, ['m1'])).not.toBeNull();
+  });
+});
+
+// --- evaluateLabels ---
+
+// Helper to build a labelSlice from a plain object
+function makeSlice(
+  data: Record<string, Record<string, string>>,
+): Map<string, Map<string, string>> {
+  return new Map(
+    Object.entries(data).map(([taskId, modelMap]) => [
+      taskId,
+      new Map(Object.entries(modelMap)),
+    ]),
+  );
+}
+
+describe('evaluateLabels', () => {
+  it('$eq matches tasks where the model has that value', () => {
+    const slice = makeSlice({
+      t1: { m1: 'force_terminated', m2: 'N/A' },
+      t2: { m1: 'N/A', m2: 'force_terminated' },
+    });
+    const result = evaluateLabels(slice, { m1: { $eq: 'force_terminated' } });
+    expect(result.has('t1')).toBe(true);
+    expect(result.has('t2')).toBe(false);
+  });
+
+  it('$neq excludes tasks where the model has that value', () => {
+    const slice = makeSlice({
+      t1: { m1: 'force_terminated' },
+      t2: { m1: 'decoder_failed' },
+    });
+    const result = evaluateLabels(slice, { m1: { $neq: 'force_terminated' } });
+    expect(result.has('t1')).toBe(false);
+    expect(result.has('t2')).toBe(true);
+  });
+
+  it('$in matches tasks where model value is in the set', () => {
+    const slice = makeSlice({
+      t1: { m1: 'force_terminated' },
+      t2: { m1: 'decoder_failed' },
+      t3: { m1: 'N/A' },
+    });
+    const result = evaluateLabels(slice, {
+      m1: { $in: ['force_terminated', 'decoder_failed'] },
+    });
+    expect(result.has('t1')).toBe(true);
+    expect(result.has('t2')).toBe(true);
+    expect(result.has('t3')).toBe(false);
+  });
+
+  it('$nin excludes tasks where model value is in the set', () => {
+    const slice = makeSlice({
+      t1: { m1: 'force_terminated' },
+      t2: { m1: 'N/A' },
+    });
+    const result = evaluateLabels(slice, {
+      m1: { $nin: ['force_terminated'] },
+    });
+    expect(result.has('t1')).toBe(false);
+    expect(result.has('t2')).toBe(true);
+  });
+
+  it('N/A is matched literally by $eq', () => {
+    const slice = makeSlice({
+      t1: { m1: 'N/A' },
+      t2: { m1: 'force_terminated' },
+    });
+    const result = evaluateLabels(slice, { m1: { $eq: 'N/A' } });
+    expect(result.has('t1')).toBe(true);
+    expect(result.has('t2')).toBe(false);
+  });
+
+  it('missing model entry defaults to N/A', () => {
+    // t1 has no entry for m2 — should default to N/A
+    const slice = makeSlice({
+      t1: { m1: 'force_terminated' },
+    });
+    const result = evaluateLabels(slice, { m2: { $eq: 'N/A' } });
+    expect(result.has('t1')).toBe(true);
+  });
+
+  it('$and returns intersection', () => {
+    const slice = makeSlice({
+      t1: { m1: 'force_terminated', m2: 'decoder_failed' },
+      t2: { m1: 'force_terminated', m2: 'N/A' },
+      t3: { m1: 'N/A', m2: 'decoder_failed' },
+    });
+    const result = evaluateLabels(slice, {
+      $and: [
+        { m1: { $eq: 'force_terminated' } },
+        { m2: { $eq: 'decoder_failed' } },
+      ],
+    });
+    expect(result.has('t1')).toBe(true);
+    expect(result.has('t2')).toBe(false);
+    expect(result.has('t3')).toBe(false);
+  });
+
+  it('$or returns union', () => {
+    const slice = makeSlice({
+      t1: { m1: 'force_terminated', m2: 'N/A' },
+      t2: { m1: 'N/A', m2: 'decoder_failed' },
+      t3: { m1: 'N/A', m2: 'N/A' },
+    });
+    const result = evaluateLabels(slice, {
+      $or: [
+        { m1: { $eq: 'force_terminated' } },
+        { m2: { $eq: 'decoder_failed' } },
+      ],
+    });
+    expect(result.has('t1')).toBe(true);
+    expect(result.has('t2')).toBe(true);
+    expect(result.has('t3')).toBe(false);
+  });
+
+  it('primitive shorthand is treated as $eq', () => {
+    const slice = makeSlice({
+      t1: { m1: 'force_terminated' },
+      t2: { m1: 'N/A' },
+    });
+    const result = evaluateLabels(slice, { m1: 'force_terminated' });
+    expect(result.has('t1')).toBe(true);
+    expect(result.has('t2')).toBe(false);
+  });
+
+  it('multi-model condition: both models must satisfy', () => {
+    const slice = makeSlice({
+      t1: { m1: 'force_terminated', m2: 'force_terminated' },
+      t2: { m1: 'force_terminated', m2: 'N/A' },
+    });
+    const result = evaluateLabels(slice, {
+      m1: { $eq: 'force_terminated' },
+      m2: { $eq: 'force_terminated' },
+    });
+    expect(result.has('t1')).toBe(true);
+    expect(result.has('t2')).toBe(false);
+  });
+});

--- a/src/__tests__/objects.test.ts
+++ b/src/__tests__/objects.test.ts
@@ -72,6 +72,24 @@ describe('camelCaseKeys', () => {
     expect(camelCaseKeys([] as any)).toEqual([]);
   });
 
+  it('does not recurse into labels — snake_case label keys pass through unchanged', () => {
+    const input = {
+      task_id: 't1',
+      labels: { error_type: 'force_terminated', response_language: 'fr' },
+    };
+    const result = camelCaseKeys(input);
+    expect(result).toEqual({
+      taskId: 't1',
+      labels: { error_type: 'force_terminated', response_language: 'fr' },
+    });
+  });
+
+  it('does not recurse into labels when the value is null', () => {
+    const input = { task_id: 't1', labels: { error_type: null } };
+    const result = camelCaseKeys(input);
+    expect(result).toEqual({ taskId: 't1', labels: { error_type: null } });
+  });
+
   it('converts all default keys', () => {
     const input = {
       task_id: 'a',
@@ -138,6 +156,18 @@ describe('snakeCaseKeys', () => {
     const result = snakeCaseKeys(input, ['fooBar']);
     expect(result).toHaveProperty('foo_bar', 'val');
     expect(result).toHaveProperty('taskId', 'keep');
+  });
+
+  it('does not recurse into labels — label keys pass through unchanged on export round-trip', () => {
+    const input = {
+      taskId: 't1',
+      labels: { error_type: 'ast_decoder:decoder_failed' },
+    };
+    const result = snakeCaseKeys(input);
+    expect(result).toEqual({
+      task_id: 't1',
+      labels: { error_type: 'ast_decoder:decoder_failed' },
+    });
   });
 });
 

--- a/src/__tests__/processor.test.ts
+++ b/src/__tests__/processor.test.ts
@@ -329,6 +329,31 @@ describe('processData', () => {
     expect(data.documents).toHaveLength(1);
   });
 
+  // --- labels pass-through ---
+
+  it('preserves labels on qualified results with snake_case keys intact', () => {
+    const raw = minimalData();
+    (raw.results[0] as any).labels = {
+      error_type: 'force_terminated',
+      response_language: null,
+    };
+
+    const [data] = processData(raw);
+    const result = data.results.find(
+      (r) => r.taskId === 't1' && r.modelId === 'm1',
+    );
+    expect(result?.labels).toEqual({
+      error_type: 'force_terminated',
+      response_language: null,
+    });
+  });
+
+  it('qualifies results that have no labels field', () => {
+    const [data] = processData(minimalData());
+    expect(data.results).toHaveLength(2);
+    data.results.forEach((r) => expect(r.labels).toBeUndefined());
+  });
+
   // --- migrated flag ---
 
   it('sets migrated=true on the returned Data when the flag is passed in', () => {

--- a/src/components/expression-builder/ExpressionBuilder.tsx
+++ b/src/components/expression-builder/ExpressionBuilder.tsx
@@ -92,6 +92,7 @@ export default function ExpressionBuilder({
                   Comparison: $eq &nbsp;$neq &nbsp;$gt &nbsp;$gte &nbsp;$lt
                   &nbsp;$lte
                 </p>
+                <p>Set: $in &nbsp;$nin</p>
                 <p>Logical: $and &nbsp;$or</p>
                 <p>
                   <strong>Examples</strong>
@@ -103,6 +104,10 @@ export default function ExpressionBuilder({
                   <ListItem>
                     Multi-model:{' '}
                     {`{ "model-a": { "$gte": 3 }, "model-b": { "$lt": 2 } }`}
+                  </ListItem>
+                  <ListItem>
+                    Set membership:{' '}
+                    {`{ "model-a": { "$in": ["good", "excellent"] } }`}
                   </ListItem>
                   <ListItem>
                     AND:{' '}

--- a/src/components/filters/Filters.tsx
+++ b/src/components/filters/Filters.tsx
@@ -20,7 +20,7 @@
 
 import { isEmpty, omit } from 'lodash';
 import cx from 'classnames';
-import { useState } from 'react';
+import { useState, ReactNode } from 'react';
 
 import {
   FilterableMultiSelect,
@@ -53,6 +53,10 @@ interface Props {
   metric?: Metric;
   expression?: object;
   setExpression?: Function;
+  // Slot for a custom expression builder component. When provided, replaces the
+  // default ExpressionBuilder in the Expression tab (used by ModelCharacteristics
+  // which needs label semantics, not metric semantics).
+  expressionBuilder?: ReactNode;
 }
 
 // ===================================================================================
@@ -67,10 +71,17 @@ export default function Filters({
   metric,
   expression,
   setExpression,
+  expressionBuilder,
 }: Props) {
+  // Show the expression tab when either the metric-based builder or the custom
+  // slot is supplied alongside an expression state.
+  const hasExpressionTab =
+    expression !== undefined &&
+    (setExpression !== undefined || expressionBuilder !== undefined);
+
   // Hide the filter panel when neither static filters nor expression builder is available
   const [showFilters, setShowFilters] = useState<boolean>(
-    filters !== undefined || setExpression !== undefined,
+    filters !== undefined || hasExpressionTab,
   );
 
   return (
@@ -107,7 +118,7 @@ export default function Filters({
       )}
       <div className={cx(classes.container, showFilters && classes.visible)}>
         {showFilters ? (
-          filters && expression ? (
+          filters && hasExpressionTab ? (
             <Tabs>
               <TabList aria-label="additional filters" contained fullWidth>
                 <Tab>Static</Tab>
@@ -190,14 +201,18 @@ export default function Filters({
                   </div>
                 </TabPanel>
                 <TabPanel>
-                  <div key={hash(JSON.stringify(expression))}>
-                    <ExpressionBuilder
-                      expression={expression}
-                      models={models}
-                      metric={metric}
-                      setExpression={setExpression}
-                    ></ExpressionBuilder>
-                  </div>
+                  {expressionBuilder ? (
+                    expressionBuilder
+                  ) : (
+                    <div key={hash(JSON.stringify(expression))}>
+                      <ExpressionBuilder
+                        expression={expression}
+                        models={models}
+                        metric={metric}
+                        setExpression={setExpression}
+                      ></ExpressionBuilder>
+                    </div>
+                  )}
                 </TabPanel>
               </TabPanels>
             </Tabs>
@@ -268,15 +283,19 @@ export default function Filters({
                 );
               })}
             </div>
-          ) : expression ? (
-            <div key={hash(JSON.stringify(expression))}>
-              <ExpressionBuilder
-                expression={expression}
-                models={models}
-                metric={metric}
-                setExpression={setExpression}
-              ></ExpressionBuilder>
-            </div>
+          ) : hasExpressionTab ? (
+            expressionBuilder ? (
+              expressionBuilder
+            ) : (
+              <div key={hash(JSON.stringify(expression))}>
+                <ExpressionBuilder
+                  expression={expression}
+                  models={models}
+                  metric={metric}
+                  setExpression={setExpression}
+                ></ExpressionBuilder>
+              </div>
+            )
           ) : null
         ) : null}
       </div>

--- a/src/exporter.ts
+++ b/src/exporter.ts
@@ -43,6 +43,7 @@ export function exportData(
           modelId: evaluation.modelId,
           output: evaluation.output,
           scores: evaluation.scores,
+          ...(evaluation.labels && { labels: evaluation.labels }),
           ...(evaluation.contexts && { contexts: evaluation.contexts }),
         };
       }),

--- a/src/types.ts
+++ b/src/types.ts
@@ -316,6 +316,13 @@ export interface ModelResult {
   // Evaluation-level comments (e.g. noting an acceptable-but-different tool call).
   // Distinct from task.comments which are task-level observations shared across models.
   comments?: TaskComment[];
+  // Per-(task, model) categorical descriptors with no implied ordering. Keys are
+  // producer vocabulary (snake_case strings, e.g. "error_type"); values are short
+  // human-readable strings or null when the label is not applicable for this task.
+  // Omitting the key is equivalent to null — both are treated as N/A in the UI.
+  // camelCaseKeys must NOT recurse into this dict: label keys are producer vocabulary
+  // and must pass through as-is.
+  labels?: Record<string, string | null>;
   // Benchmark-supplied metadata. Keys are benchmark-specific; the UI renders
   // known keys and ignores unknown ones.
   // Known keys: error — { kind: 'text' | 'structured', context: unknown }

--- a/src/utilities/expressions.ts
+++ b/src/utilities/expressions.ts
@@ -36,6 +36,10 @@ export enum EXPRESSION_OPERATORS {
   GTE = '$gte',
   LT = '$lt',
   LTE = '$lte',
+
+  // Set membership operators
+  IN = '$in',
+  NIN = '$nin',
 }
 
 export function validate(
@@ -115,6 +119,26 @@ export function validate(
         typeof expression[operator] !== 'number'
       ) {
         return `Comparison operator ("${operator}") must follow primitive data types ("string" or "number")`;
+      }
+    }
+    // Set membership operators condition
+    else if (
+      operator === EXPRESSION_OPERATORS.IN ||
+      operator === EXPRESSION_OPERATORS.NIN
+    ) {
+      if (parent === undefined || parent.startsWith('$')) {
+        return `Set operator ("${operator}") must preceed with model ID`;
+      }
+      if (
+        !Array.isArray(expression[operator]) ||
+        expression[operator].some(
+          (v) => typeof v !== 'string' && typeof v !== 'number',
+        )
+      ) {
+        return `Set operator ("${operator}") must follow with an array of primitive values ("string" or "number")`;
+      }
+      if (expression[operator].length === 0) {
+        return `Set operator ("${operator}") cannot have an empty array`;
       }
     }
   } else {
@@ -293,6 +317,28 @@ export function evaluate(
             satisfy = false;
             break;
           }
+
+          // If comparison operator is "$in"
+          if (operator === EXPRESSION_OPERATORS.IN) {
+            const numericSet = expectation[operator].map((v) =>
+              castToNumber(v, metric.values),
+            );
+            if (isNaN(value) || !numericSet.includes(value)) {
+              satisfy = false;
+              break;
+            }
+          }
+
+          // If comparison operator is "$nin"
+          if (operator === EXPRESSION_OPERATORS.NIN) {
+            const numericSet = expectation[operator].map((v) =>
+              castToNumber(v, metric.values),
+            );
+            if (isNaN(value) || numericSet.includes(value)) {
+              satisfy = false;
+              break;
+            }
+          }
         } else {
           // Primitive expectation: direct equality check
           if (
@@ -317,4 +363,235 @@ export function evaluate(
   }
 
   return eligibleResults;
+}
+
+// --- Label expressions ---
+
+// Validates an expression for use with labels. Same structural rules as
+// validate(), but rejects ordering operators ($gt, $gte, $lt, $lte) because
+// labels are nominal — no ordering exists.
+export function validateLabelExpression(
+  expression: object,
+  modelIds?: string[],
+  parent?: string,
+): string | null {
+  const keys = Object.keys(expression);
+
+  if (keys.length === 0 && parent === undefined) {
+    return 'Expression cannot be empty';
+  }
+
+  const operators = keys.filter((key) => key.startsWith('$'));
+  if (operators.length > 1) {
+    return `More than one operator [${operators.join(', ')}] on the same level in the expression`;
+  }
+
+  if (operators.length === 1 && keys.length > 1) {
+    return 'Additional keys on the same level in the expression';
+  }
+
+  if (operators.length === 1) {
+    const operator = operators[0];
+
+    if (
+      operator === EXPRESSION_OPERATORS.AND ||
+      operator === EXPRESSION_OPERATORS.OR
+    ) {
+      if (parent && modelIds && modelIds.includes(parent)) {
+        return `Logical operator ("${operator}") must not preceed with model ID`;
+      }
+      if (
+        !Array.isArray(expression[operator]) ||
+        expression[operator].some((value) => typeof value !== 'object')
+      ) {
+        return `Logical operator ("${operator}") must follow with array of expressions`;
+      }
+      if (
+        isEmpty(expression[operator]) ||
+        expression[operator].some((entry) => isEmpty(entry))
+      ) {
+        return `Logical operator ("${operator}") cannot have empty expression value`;
+      }
+      for (let index = 0; index < expression[operator].length; index++) {
+        const nestedError = validateLabelExpression(
+          expression[operator][index],
+          modelIds,
+        );
+        if (nestedError) return nestedError;
+      }
+    } else if (
+      operator === EXPRESSION_OPERATORS.EQ ||
+      operator === EXPRESSION_OPERATORS.NEQ
+    ) {
+      if (parent === undefined || parent.startsWith('$')) {
+        return `Comparison operator ("${operator}") must preceed with model ID`;
+      }
+      if (
+        typeof expression[operator] !== 'string' &&
+        typeof expression[operator] !== 'number'
+      ) {
+        return `Comparison operator ("${operator}") must follow primitive data types ("string" or "number")`;
+      }
+    } else if (
+      operator === EXPRESSION_OPERATORS.IN ||
+      operator === EXPRESSION_OPERATORS.NIN
+    ) {
+      if (parent === undefined || parent.startsWith('$')) {
+        return `Set operator ("${operator}") must preceed with model ID`;
+      }
+      if (
+        !Array.isArray(expression[operator]) ||
+        expression[operator].some(
+          (v) => typeof v !== 'string' && typeof v !== 'number',
+        )
+      ) {
+        return `Set operator ("${operator}") must follow with an array of primitive values ("string" or "number")`;
+      }
+      if (expression[operator].length === 0) {
+        return `Set operator ("${operator}") cannot have an empty array`;
+      }
+    } else if (
+      operator === EXPRESSION_OPERATORS.GT ||
+      operator === EXPRESSION_OPERATORS.GTE ||
+      operator === EXPRESSION_OPERATORS.LT ||
+      operator === EXPRESSION_OPERATORS.LTE
+    ) {
+      return `Ordering operator ("${operator}") is not valid for labels — labels have no ordering`;
+    } else {
+      return `Unknown operator ("${operator}")`;
+    }
+  } else {
+    for (let idx = 0; idx < keys.length; idx++) {
+      if (modelIds && !modelIds.includes(keys[idx])) {
+        return `Model ("${keys[idx]}") does not exist. Please use one of the following models: ${modelIds.join(', ')}`;
+      }
+      const value = expression[keys[idx]];
+      if (
+        typeof value !== 'object' &&
+        typeof value !== 'string' &&
+        typeof value !== 'number'
+      ) {
+        return `Model ("${keys[idx]}") must follow either expression or primitive data types ("string" or "number")`;
+      }
+      if (typeof value === 'object') {
+        const nestedError = validateLabelExpression(
+          expression[keys[idx]],
+          modelIds,
+          keys[idx],
+        );
+        if (nestedError) return nestedError;
+      }
+    }
+  }
+
+  return null;
+}
+
+// Evaluates a label expression against a labelsIndex slice.
+//
+// labelSlice: Map<taskId, Map<modelId, string>> — the labelsIndex entry for
+// one label key. Values are raw producer strings or "N/A" for absent/null.
+//
+// Returns the set of taskIds whose per-model label values satisfy the expression.
+// Supports $eq, $neq, $in, $nin, $and, $or. Ordering operators are not supported
+// and should be rejected by validateLabelExpression before reaching here.
+export function evaluateLabels(
+  labelSlice: Map<string, Map<string, string>>,
+  expression: object,
+): Set<string> {
+  const keys = Object.keys(expression);
+  const operators = keys.filter((key) => key.startsWith('$'));
+
+  if (operators.length === 1) {
+    const operator = operators[0];
+
+    if (
+      operator === EXPRESSION_OPERATORS.AND ||
+      operator === EXPRESSION_OPERATORS.OR
+    ) {
+      const subResults: Set<string>[] = expression[operator].map((condition) =>
+        evaluateLabels(labelSlice, condition),
+      );
+
+      if (operator === EXPRESSION_OPERATORS.AND) {
+        // Intersection: start from the first set, keep only items in all others
+        return subResults.reduce((acc, set) => {
+          const result = new Set<string>();
+          for (const taskId of acc) {
+            if (set.has(taskId)) result.add(taskId);
+          }
+          return result;
+        });
+      } else {
+        // Union: merge all sets
+        return subResults.reduce((acc, set) => {
+          for (const taskId of set) acc.add(taskId);
+          return acc;
+        }, new Set<string>());
+      }
+    }
+  }
+
+  // No logical operator: evaluate per-model conditions against each task
+  const matched = new Set<string>();
+
+  for (const [taskId, modelValues] of labelSlice) {
+    let satisfy = true;
+
+    for (let idx = 0; idx < keys.length; idx++) {
+      const modelId = keys[idx];
+      // Value for this model on this task, defaulting to N/A if not present
+      const value = modelValues.get(modelId) ?? 'N/A';
+      const expectation = expression[modelId];
+
+      if (typeof expectation === 'object') {
+        const operator = Object.keys(expectation).find((k) =>
+          k.startsWith('$'),
+        );
+        if (!operator) {
+          satisfy = false;
+          break;
+        }
+
+        if (
+          operator === EXPRESSION_OPERATORS.EQ &&
+          value !== expectation[operator]
+        ) {
+          satisfy = false;
+          break;
+        }
+        if (
+          operator === EXPRESSION_OPERATORS.NEQ &&
+          value === expectation[operator]
+        ) {
+          satisfy = false;
+          break;
+        }
+        if (
+          operator === EXPRESSION_OPERATORS.IN &&
+          !expectation[operator].includes(value)
+        ) {
+          satisfy = false;
+          break;
+        }
+        if (
+          operator === EXPRESSION_OPERATORS.NIN &&
+          expectation[operator].includes(value)
+        ) {
+          satisfy = false;
+          break;
+        }
+      } else {
+        // Primitive shorthand: { "model-a": "value_x" } means $eq
+        if (value !== String(expectation)) {
+          satisfy = false;
+          break;
+        }
+      }
+    }
+
+    if (satisfy) matched.add(taskId);
+  }
+
+  return matched;
 }

--- a/src/utilities/objects.ts
+++ b/src/utilities/objects.ts
@@ -35,16 +35,22 @@ export function camelCaseKeys(
     'display_name',
     'depends_on',
   ],
+  // Keys whose values are passed through as-is without recursing into them.
+  // 'labels' is in the default set because label keys are producer vocabulary
+  // (e.g. "error_type") and must not be silently renamed by camelCase conversion.
+  skipKeys: string[] = ['labels'],
 ) {
   if (isArray(obj)) {
-    return obj.map((v) => camelCaseKeys(v));
+    return obj.map((v) => camelCaseKeys(v, keys, skipKeys));
   } else if (isPlainObject(obj)) {
     return Object.keys(obj).reduce(
       (result, key) => ({
         ...result,
-        ...(keys.includes(key)
-          ? { [camelCase(key)]: camelCaseKeys(obj[key]) }
-          : { [key]: camelCaseKeys(obj[key]) }),
+        ...(skipKeys.includes(key)
+          ? { [key]: obj[key] }
+          : keys.includes(key)
+            ? { [camelCase(key)]: camelCaseKeys(obj[key], keys, skipKeys) }
+            : { [key]: camelCaseKeys(obj[key], keys, skipKeys) }),
       }),
       {},
     );
@@ -66,16 +72,22 @@ export function snakeCaseKeys(
     'displayName',
     'dependsOn',
   ],
+  // Keys whose values are passed through as-is without recursing into them.
+  // 'labels' is in the default set because label keys are producer vocabulary
+  // and must survive the export round-trip unchanged.
+  skipKeys: string[] = ['labels'],
 ) {
   if (isArray(obj)) {
-    return obj.map((v) => snakeCaseKeys(v));
+    return obj.map((v) => snakeCaseKeys(v, keys, skipKeys));
   } else if (isPlainObject(obj)) {
     return Object.keys(obj).reduce(
       (result, key) => ({
         ...result,
-        ...(keys.includes(key)
-          ? { [snakeCase(key)]: snakeCaseKeys(obj[key]) }
-          : { [key]: snakeCaseKeys(obj[key]) }),
+        ...(skipKeys.includes(key)
+          ? { [key]: obj[key] }
+          : keys.includes(key)
+            ? { [snakeCase(key)]: snakeCaseKeys(obj[key], keys, skipKeys) }
+            : { [key]: snakeCaseKeys(obj[key], keys, skipKeys) }),
       }),
       {},
     );

--- a/src/views/example/Example.tsx
+++ b/src/views/example/Example.tsx
@@ -30,6 +30,7 @@ import {
   ChartMultitype,
   Compare,
   HeatMap_03,
+  Tag,
 } from '@carbon/icons-react';
 
 import { Data, ModelResult } from '@/src/types';
@@ -47,6 +48,7 @@ import AnnotatorBehavior from '@/src/views/annotator-behavior/AnnotatorBehavior'
 import ModelBehavior from '@/src/views/model-behavior/ModelBehavior';
 import ModelComparator from '@/src/views/model-comparator/ModelComparator';
 import MetricBehavior from '@/src/views/metric-behavior/MetricBehavior';
+import ModelCharacteristics from '@/src/views/model-characteristics/ModelCharacteristics';
 
 import classes from './Example.module.scss';
 
@@ -233,6 +235,58 @@ export default memo(function Example({ data }: { data: Data }) {
     ];
   }, [data.results, data.tasks, data.models, data.filters, eligibleMetricsMap]);
 
+  // labelsIndex: Map<labelKey, Map<taskId, Map<modelId, string>>>
+  //
+  // Built from result.labels on each qualified result. Absent or explicit null
+  // values are stored as "N/A" so the expression evaluator and value selector
+  // can treat "N/A" as a regular string — a user who sees an N/A bar in the
+  // chart must be able to write { "model-a": { "$eq": "N/A" } } and get results.
+  //
+  // The index is dense: once a label key is seen anywhere, every (taskId, modelId)
+  // pair gets an explicit entry for it (defaulting to "N/A"), so evaluateLabels
+  // never needs to distinguish "key absent" from "key present with null value".
+  const labelsIndex = useMemo(() => {
+    const index = new Map<string, Map<string, Map<string, string>>>();
+
+    // First pass: discover all label keys and seed the index with N/A for
+    // every (taskId, modelId) pair, so the index is dense before we fill values.
+    const allLabelKeys = new Set<string>();
+    data.results.forEach((evaluation) => {
+      if (evaluation.labels) {
+        Object.keys(evaluation.labels).forEach((key) => allLabelKeys.add(key));
+      }
+    });
+
+    if (allLabelKeys.size === 0) return index;
+
+    allLabelKeys.forEach((key) => {
+      const taskMap = new Map<string, Map<string, string>>();
+      data.tasks.forEach((task) => {
+        const modelMap = new Map<string, string>();
+        data.models.forEach((model) => modelMap.set(model.modelId, 'N/A'));
+        taskMap.set(task.taskId, modelMap);
+      });
+      index.set(key, taskMap);
+    });
+
+    // Second pass: fill in the actual label values from each result.
+    data.results.forEach((evaluation) => {
+      if (!evaluation.labels) return;
+      for (const [key, rawValue] of Object.entries(evaluation.labels)) {
+        const taskMap = index.get(key);
+        if (!taskMap) continue;
+        const modelMap = taskMap.get(evaluation.taskId);
+        if (!modelMap) continue;
+        modelMap.set(
+          evaluation.modelId,
+          rawValue === null || rawValue === undefined ? 'N/A' : rawValue,
+        );
+      }
+    });
+
+    return index;
+  }, [data.results, data.tasks, data.models]);
+
   const {} = useBackButton();
 
   return (
@@ -279,6 +333,9 @@ export default memo(function Example({ data }: { data: Data }) {
             </Tab>
             <Tab key={'metric-behavior-tab'} renderIcon={HeatMap_03}>
               Metric Behavior
+            </Tab>
+            <Tab key={'model-characteristics-tab'} renderIcon={Tag}>
+              Model Characteristics
             </Tab>
           </TabList>
           <TabPanels>
@@ -356,6 +413,20 @@ export default memo(function Example({ data }: { data: Data }) {
                     setSelectedTaskId(taskId);
                   }}
                 ></MetricBehavior>
+              )}
+            </TabPanel>
+            <TabPanel key={'model-characteristics-panel'}>
+              {labelsIndex.size === 0 ? (
+                <DisabledTab message="This dataset has no labels. Add a 'labels' field to model results to explore model characteristics." />
+              ) : (
+                <ModelCharacteristics
+                  labelsIndex={labelsIndex}
+                  models={data.models}
+                  filters={filters}
+                  onTaskSelection={(taskId) => {
+                    setSelectedTaskId(taskId);
+                  }}
+                />
               )}
             </TabPanel>
           </TabPanels>

--- a/src/views/model-characteristics/ModelCharacteristics.module.scss
+++ b/src/views/model-characteristics/ModelCharacteristics.module.scss
@@ -1,0 +1,115 @@
+/**
+ *
+ * Copyright 2023-present InspectorRAGet Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **/
+
+@use '@carbon/react/scss/spacing' as *;
+@use '@carbon/colors' as *;
+
+.page {
+  display: flex;
+  flex-direction: column;
+}
+
+.selectors {
+  display: flex;
+  align-items: baseline;
+  column-gap: $spacing-09;
+}
+
+.labelSelector {
+  width: 20%;
+}
+
+.modelSelector {
+  width: 20%;
+}
+
+.valueSelector {
+  width: 20%;
+}
+
+.valueSelectorLabel {
+  display: flex;
+  align-items: center;
+  column-gap: $spacing-02;
+}
+
+.tagList {
+  :global(.cds--tag) {
+    margin: $spacing-01;
+  }
+}
+
+.row {
+  margin: $spacing-05 0;
+}
+
+.graphsGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: $spacing-05 $spacing-09;
+}
+
+.graphsFlex {
+  margin: $spacing-03 0;
+  display: flex;
+  justify-content: space-around;
+}
+
+.graph {
+  display: flex;
+  flex-direction: column;
+  row-gap: $spacing-03;
+  align-items: center;
+}
+
+.graphTitle {
+  display: flex;
+  column-gap: $spacing-02;
+}
+
+.otherList {
+  max-height: 200px;
+  overflow-y: auto;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+
+  li {
+    padding: $spacing-01 0;
+    font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  }
+}
+
+.warningContainer {
+  width: 100%;
+  margin: $spacing-09 0;
+  display: flex;
+  column-gap: $spacing-03;
+  justify-content: center;
+  align-items: flex-end;
+}
+
+.warningContainerIcon {
+  color: $gray-50;
+}
+
+.warningContainerText {
+  font-size: 26px;
+  line-height: 28px;
+  color: $gray-50;
+}

--- a/src/views/model-characteristics/ModelCharacteristics.tsx
+++ b/src/views/model-characteristics/ModelCharacteristics.tsx
@@ -1,0 +1,744 @@
+/**
+ *
+ * Copyright 2023-present InspectorRAGet Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **/
+
+'use client';
+
+import { isEmpty } from 'lodash';
+import cx from 'classnames';
+import { useState, useMemo } from 'react';
+import {
+  Select,
+  SelectItem,
+  FilterableMultiSelect,
+  Tag,
+  Toggletip,
+  ToggletipButton,
+  ToggletipContent,
+  TextArea,
+  Button,
+  UnorderedList,
+  ListItem,
+} from '@carbon/react';
+import { WarningAlt, Information } from '@carbon/icons-react';
+import { GroupedBarChart } from '@carbon/charts-react';
+import { ScaleTypes } from '@carbon/charts';
+
+import { useTheme } from '@/src/theme';
+import { Model, ModelResult } from '@/src/types';
+import { getModelColorPalette } from '@/src/utilities/colors';
+import {
+  validateLabelExpression,
+  evaluateLabels,
+  PLACEHOLDER_EXPRESSION_TEXT,
+} from '@/src/utilities/expressions';
+import { areObjectsIntersecting } from '@/src/utilities/objects';
+import Filters from '@/src/components/filters/Filters';
+import TasksTable from '@/src/views/tasks-table/TasksTable';
+import { useDataStore } from '@/src/store';
+
+import '@carbon/charts-react/styles.css';
+import classes from './ModelCharacteristics.module.scss';
+
+// --- Types ---
+
+interface Props {
+  labelsIndex: Map<string, Map<string, Map<string, string>>>;
+  models: Model[];
+  filters: { [key: string]: string[] };
+  onTaskSelection: (taskId: string) => void;
+}
+
+// Maximum number of producer-declared values shown as distinct bars.
+// Values beyond this are collapsed into "Other" in the chart and value selector.
+const TOP_N = 10;
+const NA_VALUE = 'N/A';
+const OTHER_VALUE = 'Other';
+
+// --- Helpers ---
+
+// Returns the top-N label values by total occurrence count across all models,
+// plus the full sorted tail (values that fall outside the top-N).
+function computeTopValues(labelSlice: Map<string, Map<string, string>>): {
+  topValues: string[];
+  otherValues: string[];
+} {
+  const counts = new Map<string, number>();
+
+  for (const modelMap of labelSlice.values()) {
+    for (const value of modelMap.values()) {
+      if (value === NA_VALUE) continue;
+      counts.set(value, (counts.get(value) ?? 0) + 1);
+    }
+  }
+
+  const sorted = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  const topValues = sorted.slice(0, TOP_N).map(([v]) => v);
+  const otherValues = sorted.slice(TOP_N).map(([v]) => v);
+  return { topValues, otherValues };
+}
+
+// Builds the chart dataset from a label slice, task filter, and display values.
+// Returns an array of { group, key, value } entries where value is a percentage.
+function buildChartData(
+  labelSlice: Map<string, Map<string, string>>,
+  filteredTaskIds: Set<string>,
+  topValues: string[],
+  otherValues: string[],
+  models: Model[],
+): { group: string; key: string; value: number }[] {
+  const counts: Map<string, Map<string, number>> = new Map();
+  const totals: Map<string, number> = new Map();
+
+  models.forEach((m) => {
+    counts.set(m.modelId, new Map());
+    totals.set(m.modelId, 0);
+  });
+
+  for (const [taskId, modelMap] of labelSlice) {
+    if (!filteredTaskIds.has(taskId)) continue;
+    for (const [modelId, value] of modelMap) {
+      if (!counts.has(modelId)) continue;
+      const bucket = topValues.includes(value)
+        ? value
+        : value === NA_VALUE
+          ? NA_VALUE
+          : OTHER_VALUE;
+      counts
+        .get(modelId)!
+        .set(bucket, (counts.get(modelId)!.get(bucket) ?? 0) + 1);
+      totals.set(modelId, (totals.get(modelId) ?? 0) + 1);
+    }
+  }
+
+  // Determine which buckets to render: top values + Other (if any) + N/A (if any)
+  const bucketsToShow: string[] = [...topValues];
+  const hasOther = otherValues.length > 0;
+  const hasNA = models.some(
+    (m) => (counts.get(m.modelId)?.get(NA_VALUE) ?? 0) > 0,
+  );
+  if (hasOther) bucketsToShow.push(OTHER_VALUE);
+  if (hasNA) bucketsToShow.push(NA_VALUE);
+
+  const result: { group: string; key: string; value: number }[] = [];
+  for (const model of models) {
+    const modelCounts = counts.get(model.modelId)!;
+    const total = totals.get(model.modelId) ?? 0;
+    for (const bucket of bucketsToShow) {
+      const count = modelCounts.get(bucket) ?? 0;
+      result.push({
+        group: model.name,
+        key: bucket,
+        value:
+          total > 0
+            ? Math.round(((count / total) * 100 + Number.EPSILON) * 100) / 100
+            : 0,
+      });
+    }
+  }
+  return result;
+}
+
+// --- ExpressionBuilderForLabels ---
+
+// Expression builder scoped to label semantics: only $eq, $neq, $in, $nin,
+// $and, $or. Surfaces the full value vocabulary in helper text so the user can
+// write expressions against values that are collapsed into "Other" in the chart.
+
+interface ExpressionBuilderForLabelsProps {
+  expression: object;
+  models: Model[];
+  labelKey: string;
+  valueOptions: string[];
+  disabled: boolean;
+  setExpression: (expr: object) => void;
+}
+
+function ExpressionBuilderForLabels({
+  expression,
+  models,
+  labelKey,
+  valueOptions,
+  disabled,
+  setExpression,
+}: ExpressionBuilderForLabelsProps) {
+  const [text, setText] = useState(PLACEHOLDER_EXPRESSION_TEXT);
+
+  // When expression is cleared externally (label key change, value selector used),
+  // display the placeholder regardless of what the text buffer holds. The parent-
+  // driven clear is an explicit reset — the user's in-progress text is intentionally
+  // discarded.
+  const displayText = isEmpty(expression) ? PLACEHOLDER_EXPRESSION_TEXT : text;
+
+  const validationError = (() => {
+    try {
+      const parsed = JSON.parse(displayText);
+      return validateLabelExpression(
+        parsed,
+        models.map((m) => m.modelId),
+      );
+    } catch {
+      return 'Invalid JSON';
+    }
+  })();
+
+  return (
+    <div>
+      <TextArea
+        labelText={
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <span>Expression</span>
+            <Toggletip align="bottom-left">
+              <ToggletipButton label="Syntax reference">
+                <Information />
+              </ToggletipButton>
+              <ToggletipContent>
+                <p>
+                  <strong>Operators</strong>
+                </p>
+                <p>Comparison: $eq &nbsp;$neq</p>
+                <p>Set: $in &nbsp;$nin</p>
+                <p>Logical: $and &nbsp;$or</p>
+                <p>
+                  <strong>Examples</strong>
+                </p>
+                <UnorderedList>
+                  <ListItem>
+                    {`{ "model-id": { "$eq": "force_terminated" } }`}
+                  </ListItem>
+                  <ListItem>
+                    {`{ "model-a": { "$in": ["force_terminated", "N/A"] } }`}
+                  </ListItem>
+                  <ListItem>
+                    {`{ "$and": [{ "model-a": { "$eq": "foo" } }, { "model-b": { "$neq": "foo" } }] }`}
+                  </ListItem>
+                </UnorderedList>
+                {models.length > 0 && (
+                  <p>
+                    <strong>Model IDs: </strong>
+                    {models.map((m) => m.modelId).join(', ')}
+                  </p>
+                )}
+                {valueOptions.length > 0 && (
+                  <p>
+                    <strong>All values for {labelKey}: </strong>
+                    {valueOptions.join(', ')}
+                  </p>
+                )}
+              </ToggletipContent>
+            </Toggletip>
+          </div>
+        }
+        placeholder={PLACEHOLDER_EXPRESSION_TEXT}
+        value={displayText}
+        disabled={disabled}
+        invalid={validationError !== null}
+        invalidText={validationError ?? undefined}
+        onChange={(e) => setText(e.target.value)}
+        helperText="Use model IDs as keys. Ordering operators ($gt, $gte, $lt, $lte) are not valid for labels."
+        rows={3}
+        id={`text-area__label-expression-${labelKey}`}
+      />
+      <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.5rem' }}>
+        <Button
+          kind="primary"
+          disabled={disabled || validationError !== null}
+          onClick={() => setExpression(JSON.parse(displayText))}
+        >
+          Run
+        </Button>
+        <Button
+          kind="secondary"
+          disabled={isEmpty(expression)}
+          onClick={() => {
+            setText(PLACEHOLDER_EXPRESSION_TEXT);
+            setExpression({});
+          }}
+        >
+          Clear
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// --- Main component ---
+
+export default function ModelCharacteristics({
+  labelsIndex,
+  models,
+  filters,
+  onTaskSelection,
+}: Props) {
+  const { theme } = useTheme();
+  const { item: data, resultsMap } = useDataStore();
+  const [modelColors, modelOrder] = getModelColorPalette(models);
+
+  const [selectedModels, setSelectedModels] = useState<Model[]>(models);
+  // Empty string = overview (all labels shown); non-empty = focused single-label view
+  const [selectedLabelKey, setSelectedLabelKey] = useState<string>('');
+  const [selectedValue, setSelectedValue] = useState<string>('');
+  const [selectedFilters, setSelectedFilters] = useState<{
+    [key: string]: string[];
+  }>({});
+  const [expression, setExpression] = useState<object>({});
+
+  const labelKeys = useMemo(
+    () => [...labelsIndex.keys()].sort(),
+    [labelsIndex],
+  );
+
+  // The raw slice for the focused label key (undefined when in overview mode)
+  const focusedLabelSlice = useMemo(
+    () => (selectedLabelKey ? labelsIndex.get(selectedLabelKey) : undefined),
+    [labelsIndex, selectedLabelKey],
+  );
+
+  // All label slices keyed by label key, filtered to selected tasks, for overview mode.
+  // Each entry also carries its pre-computed topValues/otherValues so the chart helper
+  // doesn't recompute on every render pass.
+  const allLabelData = useMemo(() => {
+    return labelKeys.map((key) => {
+      const slice = labelsIndex.get(key)!;
+
+      // Apply task-level static filters to this slice
+      const filteredTaskIds = new Set<string>();
+      for (const [taskId, modelMap] of slice) {
+        const task = data?.tasks.find((t) => t.taskId === taskId);
+        const taskWithFilters = task
+          ? { ...Object.fromEntries(modelMap), ...task }
+          : Object.fromEntries(modelMap);
+        if (
+          isEmpty(selectedFilters) ||
+          areObjectsIntersecting(selectedFilters, taskWithFilters)
+        ) {
+          filteredTaskIds.add(taskId);
+        }
+      }
+
+      const filteredSlice = new Map(
+        [...slice].filter(([taskId]) => filteredTaskIds.has(taskId)),
+      );
+      const { topValues, otherValues } = computeTopValues(filteredSlice);
+      const chartData = buildChartData(
+        slice,
+        filteredTaskIds,
+        topValues,
+        otherValues,
+        selectedModels,
+      );
+
+      return { key, slice, filteredTaskIds, topValues, otherValues, chartData };
+    });
+  }, [labelKeys, labelsIndex, selectedModels, selectedFilters, data?.tasks]);
+
+  // Focused-label data: task filtering, top values, chart — only computed when a
+  // label is selected. Uses the same logic as allLabelData but for one key.
+  const focusedFilteredTaskIds = useMemo(() => {
+    if (!focusedLabelSlice) return new Set<string>();
+    const result = new Set<string>();
+    for (const [taskId, modelMap] of focusedLabelSlice) {
+      const task = data?.tasks.find((t) => t.taskId === taskId);
+      const taskWithFilters = task
+        ? { ...Object.fromEntries(modelMap), ...task }
+        : Object.fromEntries(modelMap);
+      if (
+        isEmpty(selectedFilters) ||
+        areObjectsIntersecting(selectedFilters, taskWithFilters)
+      ) {
+        result.add(taskId);
+      }
+    }
+    return result;
+  }, [focusedLabelSlice, selectedFilters, data?.tasks]);
+
+  const { topValues: focusedTopValues, otherValues: focusedOtherValues } =
+    useMemo(() => {
+      if (!focusedLabelSlice) return { topValues: [], otherValues: [] };
+      const filteredSlice = new Map(
+        [...focusedLabelSlice].filter(([taskId]) =>
+          focusedFilteredTaskIds.has(taskId),
+        ),
+      );
+      return computeTopValues(filteredSlice);
+    }, [focusedLabelSlice, focusedFilteredTaskIds]);
+
+  // Tasks matching the active expression or value selector, for the task table
+  const visibleTaskIds = useMemo(() => {
+    if (!focusedLabelSlice) return new Set<string>();
+
+    if (!isEmpty(expression)) {
+      const filteredSlice = new Map(
+        [...focusedLabelSlice]
+          .filter(([taskId]) => focusedFilteredTaskIds.has(taskId))
+          .map(([taskId, modelMap]) => [
+            taskId,
+            new Map(
+              [...modelMap].filter(([modelId]) =>
+                selectedModels.some((m) => m.modelId === modelId),
+              ),
+            ),
+          ]),
+      );
+      return evaluateLabels(filteredSlice, expression);
+    }
+
+    if (selectedValue) {
+      const result = new Set<string>();
+      for (const [taskId, modelMap] of focusedLabelSlice) {
+        if (!focusedFilteredTaskIds.has(taskId)) continue;
+        for (const [modelId, value] of modelMap) {
+          if (!selectedModels.some((m) => m.modelId === modelId)) continue;
+          const bucket = focusedTopValues.includes(value)
+            ? value
+            : value === NA_VALUE
+              ? NA_VALUE
+              : OTHER_VALUE;
+          if (bucket === selectedValue) {
+            result.add(taskId);
+            break;
+          }
+        }
+      }
+      return result;
+    }
+
+    return new Set<string>();
+  }, [
+    focusedLabelSlice,
+    focusedFilteredTaskIds,
+    selectedModels,
+    selectedValue,
+    expression,
+    focusedTopValues,
+  ]);
+
+  // Denominator shift: when a value or expression is active, use visibleTaskIds
+  const focusedChartTaskIds = useMemo(() => {
+    if (selectedValue || !isEmpty(expression)) return visibleTaskIds;
+    return focusedFilteredTaskIds;
+  }, [selectedValue, expression, visibleTaskIds, focusedFilteredTaskIds]);
+
+  const focusedChartData = useMemo(() => {
+    if (!focusedLabelSlice) return [];
+    return buildChartData(
+      focusedLabelSlice,
+      focusedChartTaskIds,
+      focusedTopValues,
+      focusedOtherValues,
+      selectedModels,
+    );
+  }, [
+    focusedLabelSlice,
+    focusedChartTaskIds,
+    focusedTopValues,
+    focusedOtherValues,
+    selectedModels,
+  ]);
+
+  // Results for the task table
+  const visibleResults = useMemo(() => {
+    if (!resultsMap || visibleTaskIds.size === 0) return [];
+    const results: ModelResult[] = [];
+    for (const taskId of visibleTaskIds) {
+      for (const model of selectedModels) {
+        const result = resultsMap.get(`${taskId}::${model.modelId}`);
+        if (result) results.push(result);
+      }
+    }
+    return results;
+  }, [resultsMap, visibleTaskIds, selectedModels]);
+
+  // Per-(task, model) label values for the task table columns. Scoped to
+  // visibleTaskIds and selectedModels so the table only shows relevant rows.
+  const columnValues = useMemo(() => {
+    if (!focusedLabelSlice || visibleTaskIds.size === 0) return undefined;
+    const map = new Map<string, Map<string, string>>();
+    for (const taskId of visibleTaskIds) {
+      const modelMap = new Map<string, string>();
+      for (const model of selectedModels) {
+        modelMap.set(
+          model.modelId,
+          focusedLabelSlice.get(taskId)?.get(model.modelId) ?? '-',
+        );
+      }
+      map.set(taskId, modelMap);
+    }
+    return map;
+  }, [focusedLabelSlice, visibleTaskIds, selectedModels]);
+
+  // Value selector options for the focused label
+  const valueOptions = useMemo(() => {
+    const opts = [...focusedTopValues];
+    if (focusedOtherValues.length > 0) opts.push(OTHER_VALUE);
+    const hasNA =
+      focusedLabelSlice &&
+      [...focusedFilteredTaskIds].some((taskId) =>
+        selectedModels.some(
+          (m) => focusedLabelSlice.get(taskId)?.get(m.modelId) === NA_VALUE,
+        ),
+      );
+    if (hasNA) opts.push(NA_VALUE);
+    return opts;
+  }, [
+    focusedTopValues,
+    focusedOtherValues,
+    focusedLabelSlice,
+    focusedFilteredTaskIds,
+    selectedModels,
+  ]);
+
+  // All vocabulary for the focused label, for expression builder helper text
+  const allValueOptions = useMemo(
+    () => [...focusedTopValues, ...focusedOtherValues, NA_VALUE],
+    [focusedTopValues, focusedOtherValues],
+  );
+
+  const showTaskTable =
+    visibleTaskIds.size > 0 && (selectedValue !== '' || !isEmpty(expression));
+
+  return (
+    <div className={classes.page}>
+      <div className={classes.selectors}>
+        <div className={classes.modelSelector}>
+          <FilterableMultiSelect
+            id="model-characteristics-model-selector"
+            titleText="Choose models"
+            items={models}
+            selectedItems={selectedModels}
+            itemToString={(item) => (item ? item.name : '')}
+            onChange={(e) => setSelectedModels(e.selectedItems)}
+            invalid={selectedModels.length === 0}
+            invalidText="You must select at least one model."
+          />
+          <div className={classes.tagList}>
+            {selectedModels.map((model) => (
+              <Tag type="cool-gray" key={`model-${model.modelId}`}>
+                {model.name}
+              </Tag>
+            ))}
+          </div>
+        </div>
+
+        <div className={classes.labelSelector}>
+          <Select
+            id="model-characteristics-label-selector"
+            labelText="Choose a label"
+            value={selectedLabelKey}
+            onChange={(e) => {
+              setSelectedLabelKey(e.target.value);
+              setSelectedValue('');
+              setExpression({});
+            }}
+          >
+            <SelectItem value="" text="All" />
+            {labelKeys.map((key) => (
+              <SelectItem key={key} value={key} text={key} />
+            ))}
+          </Select>
+        </div>
+
+        {selectedLabelKey && (
+          <div className={classes.valueSelector}>
+            <Select
+              id="model-characteristics-value-selector"
+              labelText={
+                <div className={classes.valueSelectorLabel}>
+                  <span>Choose a value</span>
+                  {focusedOtherValues.length > 0 && (
+                    <Toggletip align="bottom-left">
+                      <ToggletipButton label="Values grouped under Other">
+                        <Information size={16} />
+                      </ToggletipButton>
+                      <ToggletipContent>
+                        <p>
+                          <strong>
+                            {focusedOtherValues.length} value
+                            {focusedOtherValues.length !== 1 ? 's' : ''} grouped
+                            under Other:
+                          </strong>
+                        </p>
+                        <ul className={classes.otherList}>
+                          {focusedOtherValues.map((v) => (
+                            <li key={v}>{v}</li>
+                          ))}
+                        </ul>
+                      </ToggletipContent>
+                    </Toggletip>
+                  )}
+                </div>
+              }
+              value={selectedValue}
+              disabled={!isEmpty(expression)}
+              onChange={(e) => setSelectedValue(e.target.value)}
+            >
+              <SelectItem value="" text="All" />
+              {valueOptions.map((v) => (
+                <SelectItem key={v} value={v} text={v} />
+              ))}
+            </Select>
+          </div>
+        )}
+      </div>
+
+      <Filters
+        keyPrefix="ModelCharacteristics"
+        filters={filters}
+        selectedFilters={selectedFilters}
+        setSelectedFilters={setSelectedFilters}
+        models={selectedModels}
+        expression={selectedLabelKey ? expression : undefined}
+        expressionBuilder={
+          selectedLabelKey ? (
+            <ExpressionBuilderForLabels
+              expression={expression}
+              models={selectedModels}
+              labelKey={selectedLabelKey}
+              valueOptions={allValueOptions}
+              disabled={selectedValue !== ''}
+              setExpression={(expr: object) => {
+                setExpression(expr);
+                setSelectedValue('');
+              }}
+            />
+          ) : undefined
+        }
+      />
+
+      {/* Overview mode: one chart per label key */}
+      {!selectedLabelKey && (
+        <div className={classes.row}>
+          <div
+            className={cx(
+              labelKeys.length > 3 ? classes.graphsGrid : classes.graphsFlex,
+            )}
+          >
+            {allLabelData.map(({ key, chartData, filteredTaskIds, slice }) => (
+              <div key={`label-${key}`} className={classes.graph}>
+                <h5 className={classes.graphTitle}>
+                  <strong>{key}</strong>
+                  <span>{`(${filteredTaskIds.size}/${slice.size})`}</span>
+                </h5>
+                {chartData.length === 0 ? (
+                  <div className={classes.warningContainer}>
+                    <WarningAlt
+                      height="24px"
+                      width="24px"
+                      className={classes.warningContainerIcon}
+                    />
+                    <span className={classes.warningContainerText}>
+                      No data.
+                    </span>
+                  </div>
+                ) : (
+                  <GroupedBarChart
+                    data={chartData}
+                    options={{
+                      axes: {
+                        left: {
+                          mapsTo: 'value',
+                          ticks: { formatter: (tick) => tick + '%' },
+                          domain: [0, 100],
+                        },
+                        bottom: {
+                          scaleType: ScaleTypes.LABELS,
+                          mapsTo: 'key',
+                        },
+                      },
+                      width: labelKeys.length === 1 ? '80%' : '500px',
+                      height: '500px',
+                      toolbar: { enabled: false },
+                      color: { scale: modelColors },
+                      legend: { order: modelOrder },
+                      theme,
+                    }}
+                  />
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Focused mode: single-label chart with value selector and task table */}
+      {selectedLabelKey && (
+        <>
+          {focusedChartData.length === 0 ? (
+            <div className={classes.warningContainer}>
+              <WarningAlt
+                height="32px"
+                width="32px"
+                className={classes.warningContainerIcon}
+              />
+              <span className={classes.warningContainerText}>
+                No data for the current selection.
+                {!isEmpty(selectedFilters)
+                  ? ' Try removing one or more filters.'
+                  : ''}
+              </span>
+            </div>
+          ) : (
+            <div className={classes.row}>
+              <div className={classes.graph}>
+                <h5 className={classes.graphTitle}>
+                  <strong>{selectedLabelKey}</strong>
+                  <span>{`(${focusedChartTaskIds.size}/${focusedLabelSlice?.size ?? 0})`}</span>
+                </h5>
+                <GroupedBarChart
+                  data={focusedChartData}
+                  options={{
+                    axes: {
+                      left: {
+                        mapsTo: 'value',
+                        ticks: { formatter: (tick) => tick + '%' },
+                        domain: [0, 100],
+                      },
+                      bottom: {
+                        scaleType: ScaleTypes.LABELS,
+                        mapsTo: 'key',
+                      },
+                    },
+                    width: '80%',
+                    height: '500px',
+                    toolbar: { enabled: false },
+                    color: { scale: modelColors },
+                    legend: { order: modelOrder },
+                    theme,
+                  }}
+                />
+              </div>
+            </div>
+          )}
+
+          {showTaskTable && data && (
+            <div className={classes.row}>
+              <h4>Tasks</h4>
+              <TasksTable
+                metrics={[]}
+                results={visibleResults}
+                models={selectedModels}
+                filters={filters}
+                onClick={onTaskSelection}
+                columnValues={columnValues}
+              />
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/views/tasks-table/TasksTable.tsx
+++ b/src/views/tasks-table/TasksTable.tsx
@@ -67,6 +67,10 @@ interface Props {
   filters: { [key: string]: string[] };
   annotator?: string;
   onClick: Function;
+  // When provided, takes precedence over metric scores for per-model column
+  // values. Keys are taskId → modelId → display string. Callers pass this when
+  // the column content is not a metric (e.g. label values in ModelCharacteristics).
+  columnValues?: Map<string, Map<string, string>>;
 }
 
 // --- Compute functions ---
@@ -83,6 +87,7 @@ function populateTable(
   taskInputMap: { [key: string]: any },
   filters: { [key: string]: string[] },
   annotator?: string,
+  columnValues?: Map<string, Map<string, string>>,
 ): [{ key: string; header: string }[], EvaluationRow[]] {
   const modelIds = new Set<string>();
   const applicableFilters = new Set<string>();
@@ -111,25 +116,31 @@ function populateTable(
       }
     }
 
-    // Add annotations
-    entry[`${evaluation.modelId}::value`] = {};
-    metrics.forEach((metric) => {
-      if (annotator && evaluation.hasOwnProperty(metric.name)) {
-        entry[`${evaluation.modelId}::value`][metric.name] =
-          extractMetricDisplayValue(
-            evaluation[metric.name][annotator].value,
-            metric.values,
-          );
-      } else if (evaluation.hasOwnProperty(`${metric.name}_agg`)) {
-        entry[`${evaluation.modelId}::value`][metric.name] =
-          extractMetricDisplayValue(
-            evaluation[`${metric.name}_agg`].value,
-            metric.values,
-          );
-      } else {
-        entry[`${evaluation.modelId}::value`][metric.name] = '-';
-      }
-    });
+    // columnValues takes precedence: use the caller-supplied display string
+    // directly rather than deriving it from metric scores.
+    if (columnValues) {
+      entry[`${evaluation.modelId}::value`] =
+        columnValues.get(evaluation.taskId)?.get(evaluation.modelId) ?? '-';
+    } else {
+      entry[`${evaluation.modelId}::value`] = {};
+      metrics.forEach((metric) => {
+        if (annotator && evaluation.hasOwnProperty(metric.name)) {
+          entry[`${evaluation.modelId}::value`][metric.name] =
+            extractMetricDisplayValue(
+              evaluation[metric.name][annotator].value,
+              metric.values,
+            );
+        } else if (evaluation.hasOwnProperty(`${metric.name}_agg`)) {
+          entry[`${evaluation.modelId}::value`][metric.name] =
+            extractMetricDisplayValue(
+              evaluation[`${metric.name}_agg`].value,
+              metric.values,
+            );
+        } else {
+          entry[`${evaluation.modelId}::value`][metric.name] = '-';
+        }
+      });
+    }
 
     resultsMap.set(evaluation.taskId, entry);
     modelIds.add(evaluation.modelId);
@@ -262,6 +273,7 @@ export default function TasksTable({
   filters,
   annotator,
   onClick,
+  columnValues,
 }: Props) {
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
@@ -309,8 +321,17 @@ export default function TasksTable({
           taskInputMap,
           filters,
           annotator,
+          columnValues,
         ),
-      [results, metrics, models, filters, taskInputMap, annotator],
+      [
+        results,
+        metrics,
+        models,
+        filters,
+        taskInputMap,
+        annotator,
+        columnValues,
+      ],
     );
 
   useEffect(() => {


### PR DESCRIPTION
  - Add labels field to model result schema; guard camelCaseKeys from recursing into it
  - Add labelsIndex to DataStore and ModelCharacteristics view with label distribution charts, focused mode with value selector, and per-model label columns in task table
  - Wire ExpressionBuilderForLabels into Filters via new expressionBuilder slot
  - Add columnValues prop to TasksTable for non-metric per-(task, model) display
  - Move bfcl_error_type from text metric to labels["Error Type"]
  - Fill 9 SEVERITY_MAP gaps including ast_decoder:decoder_failed (310 occurrences, was 0.5 unknown, now 1.0 malformed_output)
  - Update BFCL README: Labels section, remove bfcl_error_type from metrics table, correct Error Severity Scale sources