### PR TITLE
feat (converters): align AgentIF, ComplexBench, IFEval with public runner output layouts

### DIFF
--- a/converters/agentif/README.md
+++ b/converters/agentif/README.md
@@ -23,19 +23,19 @@ Both metrics are emitted in two variants: one including meta constraints (matchi
 ```
 run_dir/
     <model_id_1>/
-        agentif/
-            merged_for_eval/
-                results.json
+        eval/
+            results.json
     <model_id_2>/
-        agentif/
-            merged_for_eval/
-                results.json
+        eval/
+            results.json
     ...
 ```
 
-- Each immediate subdirectory of `run_dir` that contains `agentif/merged_for_eval/results.json` is treated as one model variant.
+- Each immediate subdirectory of `run_dir` that contains `eval/results.json` is treated as one model variant.
 - The subdirectory name becomes the `model_id` in the output.
 - Records are joined across models by positional index — all model directories must contain the same ordered task list.
+
+This matches the output layout of the [public AgentIF runner](https://github.com/THU-KEG/AgentIF): `run.sh` writes scored results to `results/scores/<model_id>/eval/results.json`.
 
 ## Usage
 
@@ -104,7 +104,7 @@ The `CSR` value in `accuracy.json` is a pool-level number: `total_constraints_pa
 
 - Run data lives at `runs/` (gitignored scratch space).
 - Do **not** write output files to `data/` — that directory is for shipped pre-loaded examples only.
-- Regenerate with: `python convert.py --run-dir runs/<your_run>`
+- Regenerate with: `python convert.py --run-dir runs/<your_run>` where `<your_run>` contains per-model subdirectories each with `eval/results.json`.
 
 ## Private wrapper
 

--- a/converters/agentif/convert.py
+++ b/converters/agentif/convert.py
@@ -58,18 +58,20 @@ def load_results(path: Path) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 
-def find_model_dirs(run_dir: Path) -> list[Path]:
+def find_model_dirs(run_dir: Path) -> list[tuple[Path, Path]]:
     """
-    Return subdirectories of run_dir that contain AgentIF result files at
-    <model_dir>/agentif/merged_for_eval/results.json.
+    Return (model_dir, score_file) pairs for subdirectories of run_dir that
+    contain AgentIF result files at <model_dir>/eval/results.json
+    (public runner layout).
     """
-    model_dirs = []
+    results = []
     for entry in sorted(run_dir.iterdir()):
         if not entry.is_dir():
             continue
-        if (entry / "agentif" / "merged_for_eval" / "results.json").exists():
-            model_dirs.append(entry)
-    return model_dirs
+        score_file = entry / "eval" / "results.json"
+        if score_file.exists():
+            results.append((entry, score_file))
+    return results
 
 
 # ---------------------------------------------------------------------------
@@ -109,9 +111,9 @@ def per_task_csr(constraints: list[dict], exclude_meta: bool = False) -> float:
     Returns 0.0 when no scored constraints exist.
     """
     scored = [
-        c for c in constraints
-        if c.get("score") is not None
-        and (not exclude_meta or not c.get("is_meta"))
+        c
+        for c in constraints
+        if c.get("score") is not None and (not exclude_meta or not c.get("is_meta"))
     ]
     if not scored:
         return 0.0
@@ -132,13 +134,11 @@ def task_passes(constraints: list[dict], exclude_meta: bool = False) -> bool:
     Returns False when no scored constraints exist.
     """
     scored = [
-        c for c in constraints
-        if c.get("score") is not None
-        and (not exclude_meta or not c.get("is_meta"))
+        c
+        for c in constraints
+        if c.get("score") is not None and (not exclude_meta or not c.get("is_meta"))
     ]
     return bool(scored) and all(c["score"] is True for c in scored)
-
-
 
 
 def failed_constraints_text(constraints: list[dict]) -> str:
@@ -230,40 +230,48 @@ def filter_fields_for(record: dict) -> dict[str, str]:
 # ---------------------------------------------------------------------------
 
 
-def convert(run_dir: Path, output_name: str) -> dict:
+def convert(
+    run_dir: Path,
+    output_name: str,
+    results_finder=None,
+) -> dict:
     """
     Walk run_dir, collect all model variant subdirectories containing AgentIF
     results, and produce an InspectorRAGet JSON document with task_type
     "generation".
 
     Each model directory must contain:
-        agentif/merged_for_eval/results.json
+        <model_dir>/eval/results.json
 
     Records are joined across models by positional index. All model directories
     must contain results for the same ordered task list.
+
+    results_finder is an optional callable(run_dir) -> list[tuple[Path, Path]] that
+    overrides find_model_dirs. Each tuple is (model_dir, score_file). Private
+    wrappers use this to supply internal path logic without modifying the public
+    converter.
     """
-    model_dirs = find_model_dirs(run_dir)
-    if not model_dirs:
+    model_entries = (results_finder or find_model_dirs)(run_dir)
+    if not model_entries:
         sys.exit(
             f"Error: no model directories with agentif/ results found under {run_dir}"
         )
 
     print(
-        f"Found {len(model_dirs)} model director{'y' if len(model_dirs) == 1 else 'ies'} under {run_dir}"
+        f"Found {len(model_entries)} model director{'y' if len(model_entries) == 1 else 'ies'} under {run_dir}"
     )
 
     # records_by_model[model_name] = list of records in original order
     records_by_model: dict[str, list[dict]] = {}
 
-    for model_dir in model_dirs:
+    for model_dir, score_file in model_entries:
         model_name = model_dir.name
-        score_file = model_dir / "agentif" / "merged_for_eval" / "results.json"
         print(f"\nProcessing: {model_name}")
         records = load_results(score_file)
         records_by_model[model_name] = records
         print(f"  Records: {len(records)}")
 
-    first_model_name = model_dirs[0].name
+    first_model_name = model_entries[0][0].name
     first_records = records_by_model[first_model_name]
     n_tasks = len(first_records)
 
@@ -275,7 +283,7 @@ def convert(run_dir: Path, output_name: str) -> dict:
                 f"'{first_model_name}' has {n_tasks}. All models must cover the same task set."
             )
 
-    all_model_names = [d.name for d in model_dirs]
+    all_model_names = [model_dir.name for model_dir, _ in model_entries]
     print(
         f"\nBuilding output for {n_tasks} tasks across {len(all_model_names)} model(s)..."
     )
@@ -465,7 +473,8 @@ Examples:
         type=Path,
         help=(
             "Root directory containing one subdirectory per model variant. "
-            "Each subdirectory must contain agentif/merged_for_eval/results.json."
+            "Each subdirectory must contain eval/results.json (public runner) "
+            "or agentif/merged_for_eval/results.json (internal runner)."
         ),
     )
     parser.add_argument(

--- a/converters/complexbench/README.md
+++ b/converters/complexbench/README.md
@@ -10,18 +10,16 @@ ComplexBench evaluates LLM instruction-following on complex, compositional promp
 
 ```
 run_dir/
-    <model_id_1>/
-        complexbench/
-            evaluated_model_final_results.json
-    <model_id_2>/
-        complexbench/
-            evaluated_model_final_results.json
+    <model_id_1>_final_results.json
+    <model_id_2>_final_results.json
     ...
 ```
 
-- Each immediate subdirectory of `run_dir` that contains `complexbench/evaluated_model_final_results.json` is treated as one model variant.
-- The subdirectory name becomes the `model_id` in the output.
-- All model directories must contain results for the same task set (joined on `main_id`).
+- Each `*_final_results.json` file in `run_dir` is treated as one model variant.
+- The model ID is the filename with `_final_results.json` stripped.
+- All files must contain results for the same task set (joined on `main_id`).
+
+This matches the output layout of the [public ComplexBench runner](https://github.com/thu-coai/ComplexBench): `eval.sh` writes `<model_id>_final_results.json` to a shared output directory. Run `eval.sh` once per model pointing at the same output directory, then pass that directory as `--run-dir`.
 
 ## Usage
 
@@ -32,11 +30,11 @@ python convert.py \
     --name "My ComplexBench Run"
 ```
 
-| Argument    | Required | Default                       | Description                                            |
-| ----------- | -------- | ----------------------------- | ------------------------------------------------------ |
-| `--run-dir` | yes      | —                             | Root directory with one subdirectory per model variant |
-| `--output`  | no       | `<run_dir>/complexbench.json` | Output file path                                       |
-| `--name`    | no       | `ComplexBench Evaluation`     | Display name shown in InspectorRAGet                   |
+| Argument    | Required | Default                       | Description                                                      |
+| ----------- | -------- | ----------------------------- | ---------------------------------------------------------------- |
+| `--run-dir` | yes      | —                             | Directory containing `*_final_results.json` files, one per model |
+| `--output`  | no       | `<run_dir>/complexbench.json` | Output file path                                                 |
+| `--name`    | no       | `ComplexBench Evaluation`     | Display name shown in InspectorRAGet                             |
 
 ## Output
 
@@ -83,7 +81,7 @@ The origin/coherent tests measure compositional robustness across a group of tas
 
 - Run data lives at `runs/` (gitignored scratch space).
 - Do **not** write output files to `data/` — that directory is for shipped pre-loaded examples only.
-- Regenerate with: `python convert.py --run-dir runs/<your_run>`
+- Regenerate with: `python convert.py --run-dir runs/<your_run>` where `<your_run>` contains `*_final_results.json` files.
 
 ## Private wrapper
 

--- a/converters/complexbench/convert.py
+++ b/converters/complexbench/convert.py
@@ -59,19 +59,23 @@ def load_final_results(path: Path) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 
-def find_model_dirs(run_dir: Path) -> list[Path]:
+def find_model_results(run_dir: Path) -> list[tuple[str, Path]]:
     """
-    Return subdirectories of run_dir that contain a ComplexBench score file at
-    <model_dir>/complexbench/evaluated_model_final_results.json.
+    Return (model_id, results_path) pairs for all ComplexBench score files found
+    under run_dir (public runner layout).
+
+    The public runner writes one flat file per model:
+        <run_dir>/<model_id>_final_results.json
+
+    The model ID is extracted from the filename by stripping the
+    '_final_results.json' suffix. Files are returned in sorted order so output
+    is deterministic.
     """
-    model_dirs = []
-    for entry in sorted(run_dir.iterdir()):
-        if not entry.is_dir():
-            continue
-        score_file = entry / "complexbench" / "evaluated_model_final_results.json"
-        if score_file.exists():
-            model_dirs.append(entry)
-    return model_dirs
+    results = []
+    for path in sorted(run_dir.glob("*_final_results.json")):
+        model_id = path.name[: -len("_final_results.json")]
+        results.append((model_id, path))
+    return results
 
 
 # ---------------------------------------------------------------------------
@@ -138,7 +142,10 @@ def build_labels(
     for q, passed in zip(scoring_questions, point_judges_rely):
         for dim in q.get("constraint_dimensions", []):
             dim_results.setdefault(dim, []).append(passed)
-    return {dim: ("pass" if all(verdicts) else "fail") for dim, verdicts in dim_results.items()}
+    return {
+        dim: ("pass" if all(verdicts) else "fail")
+        for dim, verdicts in dim_results.items()
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -146,44 +153,48 @@ def build_labels(
 # ---------------------------------------------------------------------------
 
 
-def convert(run_dir: Path, output_name: str) -> dict:
+def convert(
+    run_dir: Path,
+    output_name: str,
+    results_finder=None,
+) -> dict:
     """
-    Walk run_dir, collect all model variant subdirectories containing ComplexBench
-    results, and produce an InspectorRAGet JSON document with task_type "generation".
+    Walk run_dir, collect all ComplexBench result files, and produce an
+    InspectorRAGet JSON document with task_type "generation".
 
-    Each model directory must contain:
-        complexbench/evaluated_model_final_results.json
+    Each model's results must be a flat file at:
+        <run_dir>/<model_id>_final_results.json
 
     The main_id field is used as the stable join key across models. All models
     must have been evaluated on the same task set.
+
+    results_finder is an optional callable(run_dir) -> list[tuple[str, Path]] that
+    overrides find_model_results. Private wrappers can use this to supply internal
+    path logic without modifying the public converter.
     """
-    model_dirs = find_model_dirs(run_dir)
-    if not model_dirs:
-        sys.exit(
-            f"Error: no model directories with complexbench/ results found under {run_dir}"
-        )
+    model_results = (results_finder or find_model_results)(run_dir)
+    if not model_results:
+        sys.exit(f"Error: no ComplexBench result files found under {run_dir}")
 
     print(
-        f"Found {len(model_dirs)} model director{'y' if len(model_dirs) == 1 else 'ies'} under {run_dir}"
+        f"Found {len(model_results)} model result{'s' if len(model_results) != 1 else ''} under {run_dir}"
     )
 
     # records_by_model[model_name][main_id] = record dict
     records_by_model: dict[str, dict[int, dict]] = {}
 
-    for model_dir in model_dirs:
-        model_name = model_dir.name
-        score_file = model_dir / "complexbench" / "evaluated_model_final_results.json"
+    for model_name, score_file in model_results:
         print(f"\nProcessing: {model_name}")
         records = load_final_results(score_file)
         records_by_model[model_name] = {r["main_id"]: r for r in records}
         print(f"  Records: {len(records)}")
 
     # Build the ordered task list from the first model (tasks are identical across models).
-    first_model_name = model_dirs[0].name
+    first_model_name = model_results[0][0]
     first_model_records = records_by_model[first_model_name]
     ordered_ids = sorted(first_model_records.keys())
 
-    all_model_names = [d.name for d in model_dirs]
+    all_model_names = [name for name, _ in model_results]
     print(
         f"\nBuilding output for {len(ordered_ids)} tasks across {len(all_model_names)} model(s)..."
     )
@@ -196,7 +207,9 @@ def convert(run_dir: Path, output_name: str) -> dict:
 
         # Task-level fields are invariant across models; read from the first model.
         ref_record = first_model_records[main_id]
-        instruction = ref_record.get("instruction_en") or ref_record.get("instruction", "")
+        instruction = ref_record.get("instruction_en") or ref_record.get(
+            "instruction", ""
+        )
 
         task: dict = {
             "task_id": task_id,
@@ -237,7 +250,9 @@ def convert(run_dir: Path, output_name: str) -> dict:
                 },
                 "failed_constraints": {
                     ANNOTATOR: {
-                        "value": failed_constraints_text(scoring_questions, point_judges_rely),
+                        "value": failed_constraints_text(
+                            scoring_questions, point_judges_rely
+                        ),
                     }
                 },
             }
@@ -346,8 +361,9 @@ Examples:
         required=True,
         type=Path,
         help=(
-            "Root directory containing one subdirectory per model variant. "
-            "Each subdirectory must contain complexbench/evaluated_model_final_results.json."
+            "Directory containing ComplexBench result files. "
+            "Public runner layout: <run_dir>/<model_id>_final_results.json. "
+            "Internal runner layout: <run_dir>/<model_id>/complexbench/evaluated_model_final_results.json."
         ),
     )
     parser.add_argument(

--- a/converters/ifeval/README.md
+++ b/converters/ifeval/README.md
@@ -48,10 +48,6 @@ IFEval is fully self-contained. The evaluation result files include the prompt t
 
 Each invocation of `convert.py` converts one experiment. `--run-dir` points to the experiment directory. Each model evaluated in that experiment is a subdirectory inside `--run-dir`.
 
-The converter accepts two layouts:
-
-**Flat** — standard output from the google-research IFEval runner:
-
 ```
 runs/
 └── my_experiment/               ← pass this as --run-dir
@@ -63,22 +59,7 @@ runs/
         └── eval_results_loose.jsonl
 ```
 
-**Nested** — output from runners that co-locate multiple benchmark results under one model directory:
-
-```
-runs/
-└── my_experiment/
-    ├── model_a/
-    │   └── ifeval/
-    │       ├── eval_results_strict.jsonl
-    │       └── eval_results_loose.jsonl
-    └── model_b/
-        └── ifeval/
-            ├── eval_results_strict.jsonl
-            └── eval_results_loose.jsonl
-```
-
-Flat layout takes priority when both are present. `converters/ifeval/runs/` is gitignored and is a convenient local scratch space.
+This matches the standard output layout of the [google-research IFEval runner](https://github.com/google-research/google-research/tree/master/instruction_following_eval). `converters/ifeval/runs/` is gitignored and is a convenient local scratch space.
 
 To compare multiple models, place each model's directory as a sibling under a shared experiment root and point `--run-dir` at that root.
 

--- a/converters/ifeval/convert.py
+++ b/converters/ifeval/convert.py
@@ -67,40 +67,25 @@ def load_jsonl(path: Path) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 
-def _ifeval_dir(model_dir: Path) -> Path:
+def find_model_dirs(run_dir: Path) -> list[tuple[Path, Path]]:
     """
-    Resolve the directory containing IFEval result files for a model.
+    Return (model_dir, ifeval_dir) pairs for subdirectories of run_dir that
+    contain IFEval result files (public runner layout).
 
-    Accepts two layouts:
-      - Flat:   model_dir/eval_results_strict.jsonl   (standard google-research runner)
-      - Nested: model_dir/ifeval/eval_results_strict.jsonl  (multi-benchmark runners)
-
-    Flat layout takes priority. Falls back to nested if the flat files are absent.
+    The public google-research runner writes results directly into the model
+    output directory:
+        <model_dir>/eval_results_strict.jsonl
+        <model_dir>/eval_results_loose.jsonl
     """
-    for candidate in (
-        model_dir / "eval_results_strict.jsonl",
-        model_dir / "eval_results_loose.jsonl",
-    ):
-        if candidate.exists():
-            return model_dir
-    return model_dir / "ifeval"
-
-
-def find_model_dirs(run_dir: Path) -> list[Path]:
-    """
-    Return subdirectories of run_dir that contain IFEval result files,
-    in either flat or nested layout. Each such directory is one model variant.
-    """
-    model_dirs = []
+    results = []
     for entry in sorted(run_dir.iterdir()):
         if not entry.is_dir():
             continue
-        d = _ifeval_dir(entry)
-        if (d / "eval_results_strict.jsonl").exists() or (
-            d / "eval_results_loose.jsonl"
+        if (entry / "eval_results_strict.jsonl").exists() or (
+            entry / "eval_results_loose.jsonl"
         ).exists():
-            model_dirs.append(entry)
-    return model_dirs
+            results.append((entry, entry))
+    return results
 
 
 # ---------------------------------------------------------------------------
@@ -108,9 +93,9 @@ def find_model_dirs(run_dir: Path) -> list[Path]:
 # ---------------------------------------------------------------------------
 
 
-def load_ifeval_scores(model_dir: Path) -> tuple[dict[str, dict], dict[str, dict]]:
+def load_ifeval_scores(ifeval_dir: Path) -> tuple[dict[str, dict], dict[str, dict]]:
     """
-    Load strict and loose IFEval eval results for one model directory.
+    Load strict and loose IFEval eval results from ifeval_dir.
 
     Returns (strict_map, loose_map) where each map is:
         prompt_text → record dict (with follow_all_instructions, follow_instruction_list,
@@ -120,10 +105,8 @@ def load_ifeval_scores(model_dir: Path) -> tuple[dict[str, dict], dict[str, dict
     output files (the original google-research runner omits the 'key' field from
     outputs; some forks include it but it cannot be relied upon).
     """
-    d = _ifeval_dir(model_dir)
-
     def _load(filename: str) -> dict[str, dict]:
-        path = d / filename
+        path = ifeval_dir / filename
         if not path.exists():
             return {}
         result = {}
@@ -188,26 +171,31 @@ def constraint_labels(
 # ---------------------------------------------------------------------------
 
 
-def convert(run_dir: Path, output_name: str) -> dict:
+def convert(run_dir: Path, output_name: str, results_finder=None) -> dict:
     """
     Walk run_dir, collect all model variant subdirectories that contain IFEval
     results, and produce an InspectorRAGet JSON document with task_type "generation".
 
-    Each model directory must contain:
-        ifeval/eval_results_strict.jsonl
-        ifeval/eval_results_loose.jsonl   (optional but recommended)
+    Each model directory must contain (public google-research runner layout):
+        <model_dir>/eval_results_strict.jsonl
+        <model_dir>/eval_results_loose.jsonl   (optional but recommended)
 
     The prompt text is used as the join key across models and between strict/loose
     files. All models must have been run on the same prompt set.
+
+    results_finder is an optional callable(run_dir) -> list[tuple[Path, Path]]
+    that overrides find_model_dirs. Each tuple is (model_dir, ifeval_dir). Private
+    wrappers use this to supply internal path logic without modifying the public
+    converter.
     """
-    model_dirs = find_model_dirs(run_dir)
-    if not model_dirs:
+    model_entries = (results_finder or find_model_dirs)(run_dir)
+    if not model_entries:
         sys.exit(
-            f"Error: no model directories with ifeval/ results found under {run_dir}"
+            f"Error: no model directories with IFEval results found under {run_dir}"
         )
 
     print(
-        f"Found {len(model_dirs)} model director{'y' if len(model_dirs) == 1 else 'ies'} under {run_dir}"
+        f"Found {len(model_entries)} model director{'y' if len(model_entries) == 1 else 'ies'} under {run_dir}"
     )
 
     # strict_scores[model_name][prompt] = record
@@ -215,10 +203,10 @@ def convert(run_dir: Path, output_name: str) -> dict:
     strict_scores: dict[str, dict[str, dict]] = {}
     loose_scores: dict[str, dict[str, dict]] = {}
 
-    for model_dir in model_dirs:
+    for model_dir, ifeval_dir in model_entries:
         model_name = model_dir.name
         print(f"\nProcessing: {model_name}")
-        strict, loose = load_ifeval_scores(model_dir)
+        strict, loose = load_ifeval_scores(ifeval_dir)
         strict_scores[model_name] = strict
         loose_scores[model_name] = loose
         print(f"  Strict: {len(strict)} records")
@@ -229,7 +217,7 @@ def convert(run_dir: Path, output_name: str) -> dict:
     all_prompts: list[str] = []
     seen: set[str] = set()
     # Preserve order from the first model to keep task ordering stable.
-    first_model = model_dirs[0].name
+    first_model = model_entries[0][0].name
     for prompt in strict_scores.get(first_model, {}):
         if prompt not in seen:
             all_prompts.append(prompt)
@@ -242,7 +230,7 @@ def convert(run_dir: Path, output_name: str) -> dict:
                 all_prompts.append(prompt)
                 seen.add(prompt)
 
-    all_model_names = [d.name for d in model_dirs]
+    all_model_names = [model_dir.name for model_dir, _ in model_entries]
     print(
         f"\nBuilding output for {len(all_prompts)} tasks across {len(all_model_names)} model(s)..."
     )
@@ -458,7 +446,8 @@ Examples:
         type=Path,
         help=(
             "Root directory containing one subdirectory per model variant. "
-            "Each subdirectory must contain ifeval/eval_results_strict.jsonl."
+            "Each subdirectory must contain eval_results_strict.jsonl "
+            "(standard google-research IFEval runner layout)."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
Each converter's convert.py now targets the canonical output layout of its
  upstream public benchmark runner:

  - AgentIF: <model_dir>/eval/results.json (THU-KEG/AgentIF run.sh → results/scores/<model>/eval/results.json)
  - ComplexBench: flat <run_dir>/<model_id>_final_results.json files (thu-coai/ComplexBench eval.sh writes one file per model to a shared dir)
  - IFEval: <model_dir>/eval_results_strict.jsonl (google-research runner flat layout)

Introduces a results_finder parameter on each convert() function so callers
  can supply an alternative path resolution strategy without forking the
  converter logic. READMEs updated to document the expected input layout and
  link to the upstream runner for each benchmark.